### PR TITLE
Added support for longer stack names

### DIFF
--- a/cform/aws-waf-security-automations.template
+++ b/cform/aws-waf-security-automations.template
@@ -686,7 +686,14 @@
         },
         "Runtime": "python2.7",
         "MemorySize": "512",
-        "Timeout": "300"
+        "Timeout": "300",
+        "Environment": {
+          "Variables": {
+            "StackName": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        }
       }
     },
     "LambdaInvokePermissionLogParser": {
@@ -834,7 +841,14 @@
         },
         "Runtime": "nodejs4.3",
         "MemorySize": "128",
-        "Timeout": "300"
+        "Timeout": "300",
+        "Environment": {
+          "Variables": {
+            "StackName": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        }
       }
     },
     "LambdaWAFReputationListsParserEventsRule": {
@@ -1009,7 +1023,14 @@
         },
         "Runtime": "python2.7",
         "MemorySize": "128",
-        "Timeout": "300"
+        "Timeout": "300",
+        "Environment": {
+          "Variables": {
+            "StackName": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        }
       }
     },
     "LambdaInvokePermissionBadBot": {
@@ -1280,7 +1301,14 @@
         },
         "Runtime": "python2.7",
         "MemorySize": "128",
-        "Timeout": "300"
+        "Timeout": "300",
+        "Environment": {
+          "Variables": {
+            "StackName": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        }
       }
     },
     "WafWebAclRuleControler": {
@@ -1575,6 +1603,13 @@
       },
       "Condition": "LogParserActivated"
     },
+    "WhitelistIPSetID": {
+      "Description": "Whitelist IP Set ID",
+      "Value": {
+        "Ref": "WAFWhitelistSet"
+      },
+      "Condition": "LogParserActivated"
+    },
     "AutoBlockIPSetID": {
       "Description": "Auto Block IP Set ID",
       "Value": {
@@ -1625,6 +1660,13 @@
       "Value": {
         "Ref": "SendAnonymousUsageData"
       }
+    },
+    "WAFWebACLID": {
+      "Description": "Web ACL ID",
+      "Value": {
+        "Ref": "WAFWebACL"
+      },
+      "Condition": "CreateWebACL"
     },
     "UUID": {
       "Description": "Newly created random UUID.",

--- a/code/access-handler/access-handler.py
+++ b/code/access-handler/access-handler.py
@@ -13,6 +13,7 @@ import math
 import time
 import json
 import datetime
+import os
 from urllib2 import Request
 from urllib2 import urlopen
 
@@ -224,7 +225,7 @@ def lambda_handler(event, context):
         if (IP_SET_ID_BAD_BOT == None or SEND_ANONYMOUS_USAGE_DATA == None or UUID == None):
             outputs = {}
             cf = boto3.client('cloudformation')
-            stack_name = context.invoked_function_arn.split(':')[6].rsplit('-', 2)[0]
+            stack_name = os.environ['StackName']
             cf_desc = cf.describe_stacks(StackName=stack_name)
             for e in cf_desc['Stacks'][0]['Outputs']:
                 outputs[e['OutputKey']] = e['OutputValue']

--- a/code/custom-resource/custom-resource.py
+++ b/code/custom-resource/custom-resource.py
@@ -15,6 +15,7 @@ import math
 import time
 import requests
 import datetime
+import os
 from urllib2 import Request
 from urllib2 import urlopen
 
@@ -432,7 +433,7 @@ def lambda_handler(event, context):
     responseData = {}
     try:
         cf = boto3.client('cloudformation')
-        stack_name = context.invoked_function_arn.split(':')[6].rsplit('-', 2)[0]
+        stack_name = os.environ['StackName']
         cf_desc = cf.describe_stacks(StackName=stack_name)
 
         request_type = event['RequestType'].upper()

--- a/code/log-parser/log-parser.py
+++ b/code/log-parser/log-parser.py
@@ -15,6 +15,7 @@ import gzip
 import datetime
 import time
 import math
+import os
 from urllib2 import Request
 from urllib2 import urlopen
 
@@ -541,7 +542,7 @@ def lambda_handler(event, context):
 
             outputs = {}
             cf = boto3.client('cloudformation')
-            stack_name = context.invoked_function_arn.split(':')[6].rsplit('-', 2)[0]
+            stack_name = os.environ['StackName']
             cf_desc = cf.describe_stacks(StackName=stack_name)
             for e in cf_desc['Stacks'][0]['Outputs']:
                 outputs[e['OutputKey']] = e['OutputValue']

--- a/code/reputation-lists-parser/reputation-lists-parser.js
+++ b/code/reputation-lists-parser/reputation-lists-parser.js
@@ -259,15 +259,7 @@ function send_anonymous_usage_data(event, context) {
         // 0 - get reputation_ip_set_size
         function(callback) {
             // get stack name
-            var stack_name = context.functionName;
-            stack_name = stack_name.split("-");
-            stack_name.pop();
-            stack_name.pop();
-            if (stack_name.length > 1) {
-                stack_name = stack_name.join("-");
-            } else {
-                stack_name = stack_name[0];
-            }
+            var stack_name = process.env.StackName;
 
             cloudformation.describeStacks({
                 StackName: stack_name


### PR DESCRIPTION
By passing in the name of the stack the functions are associated with, we no longer depend on the 25 character limit.

This allows for stacks with longer names, or cases where the length of the name is not optional, such as nested stacks.