### PR TITLE
 updated custom-resource.py to change the way it returns the stack name.

### DIFF
--- a/source/custom-resource/custom-resource.py
+++ b/source/custom-resource/custom-resource.py
@@ -444,7 +444,7 @@ def lambda_handler(event, context):
     responseData = {}
     try:
         cf = boto3.client('cloudformation')
-        stack_name = context.invoked_function_arn.split(':')[6].rsplit('-', 2)[0]
+        stack_name=event['ResourceProperties']['StackName']
         cf_desc = cf.describe_stacks(StackName=stack_name)
 
         global waf


### PR DESCRIPTION
 this should mitigate truncation issues if the stack is launched with an
 name with additional dashes resulting in iam policy issues.

 the related CloudFormation stack will need to be updated as well to
 include the stack name passed to the custom resourse:

"WafWebAclRuleControler":{
"Properties":{
"StackName":{"Ref":"AWS::StackName"}
}