### PR TITLE
Fixing ValidationError when BadBotProtectionActivated is false

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -1072,6 +1072,7 @@
     },
     "ApiGatewayBadBotResource": {
       "Type": "AWS::ApiGateway::Resource",
+      "Condition": "BadBotProtectionActivated",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiGatewayBadBot"

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -1062,6 +1062,7 @@
     },
     "ApiGatewayBadBotResource": {
       "Type": "AWS::ApiGateway::Resource",
+      "Condition": "BadBotProtectionActivated",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiGatewayBadBot"


### PR DESCRIPTION
Got the following error when BadBotProtectionActivated is false:

```An error occurred (ValidationError) when calling the CreateStack operation: Template format error: Unresolved resource dependencies [ApiGatewayBadBot] in the Resources block of the template An error occurred (ValidationError) when calling the CreateStack operation: Template format error: Unresolved resource dependencies [ApiGatewayBadBot] in the Resources block of the template - <class 'botocore.exceptions.ClientError'>```

Condition seems to be missing on those resources.