### PR TITLE
Added missing condition of BadBotProtectionActivated for ApiGatewayBa…

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -1072,6 +1072,7 @@
     },
     "ApiGatewayBadBotResource": {
       "Type": "AWS::ApiGateway::Resource",
+      "Condition": "BadBotProtectionActivated",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiGatewayBadBot"

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -1062,6 +1062,7 @@
     },
     "ApiGatewayBadBotResource": {
       "Type": "AWS::ApiGateway::Resource",
+      "Condition": "BadBotProtectionActivated",
       "Properties": {
         "RestApiId": {
           "Ref": "ApiGatewayBadBot"


### PR DESCRIPTION
Added missing condition for ApiGatewayBadBotResource that causes dependency error if Bad Bot Protection is not activated. 

Activate Bad Bot Protection: No

<img width="1621" alt="screen shot 2017-10-15 at 11 15 58 pm" src="https://user-images.githubusercontent.com/1123564/31597745-ee1445e6-b1fe-11e7-9f67-ffd632dbc246.png">

Template validation error: Template format error: Unresolved resource dependencies [ApiGatewayBadBot] in the Resources block of the template:

<img width="1600" alt="screen shot 2017-10-15 at 11 16 23 pm" src="https://user-images.githubusercontent.com/1123564/31597757-fa44f766-b1fe-11e7-8920-dfbd0a09acad.png">