### PR TITLE
Expose the WebACL ID as stack output.

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -1584,6 +1584,12 @@
         ]]
       },
       "Condition": "BadBotProtectionActivated"
+    },
+    "WAFWebACLId": {
+      "Description": "The unique identifier (ID) for the web ACL",
+      "Value": {
+            "Ref": "WAFWebACL"
+      }
     }
   }
 }


### PR DESCRIPTION
Expose the WebACL ID so that CF stacks can use the WAF stack as a nested stack and access the WebACL so they can associate it with ALBs created in the main stack.