### PR TITLE
 Properly attaches RequestThreshold parameter to LogParser lambda environment

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -721,6 +721,9 @@
             "ERROR_PER_MINUTE_LIMIT": {
               "Ref": "ErrorThreshold"
             },
+            "REQUEST_PER_MINUTE_LIMIT": {
+              "Ref": "RequestThreshold"
+            },
             "SEND_ANONYMOUS_USAGE_DATA": {
               "Ref": "SendAnonymousUsageData"
             },


### PR DESCRIPTION
Fixes https://github.com/awslabs/aws-waf-security-automations/issues/46