### PR TITLE
YAML templates, formatting improvements, ability to control the rule action

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -1,1734 +1,1896 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "(SO0006-ALB) - AWS WAF Security Automations - ALB v2.1: This AWS CloudFormation template helps you provision the AWS WAF Security Automations stack without worrying about creating and configuring the underlying AWS infrastructure. **WARNING** This template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket, and an Amazon CloudWatch custom metric. You will be billed for the AWS resources used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License (the License). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/asl/ or in the license file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.",
-  "Metadata": {
-    "AWS::CloudFormation::Interface": {
-      "ParameterGroups": [{
-        "Label": {
-          "default": "Protection List"
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "(SO0006-ALB) - AWS WAF Security Automations - ALB v2.1: This AWS CloudFormation template helps you provision the AWS WAF Security Automations stack without worrying about creating and configuring the underlying AWS infrastructure. **WARNING** This template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket, and an Amazon CloudWatch custom metric. You will be billed for the AWS resources used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License (the License). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/asl/ or in the license file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.",
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Protection List"
+                    },
+                    "Parameters": [
+                        "SqlInjectionProtectionParam",
+                        "CrossSiteScriptingProtectionParam",
+                        "ActivateHttpFloodProtectionParam",
+                        "ActivateScansProbesProtectionParam",
+                        "ActivateReputationListsProtectionParam",
+                        "ActivateBadBotProtectionParam"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Settings"
+                    },
+                    "Parameters": [
+                        "AccessLogBucket"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Advanced Settings"
+                    },
+                    "Parameters": [
+                        "RequestThreshold",
+                        "ErrorThreshold",
+                        "WAFBlockPeriod"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Anonymous Metrics Request"
+                    },
+                    "Parameters": [
+                        "SendAnonymousUsageData"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "SqlInjectionProtectionParam": {
+                    "default": "Activate SQL Injection Protection"
+                },
+                "CrossSiteScriptingProtectionParam": {
+                    "default": "Activate Cross-site Scripting Protection"
+                },
+                "ActivateHttpFloodProtectionParam": {
+                    "default": "Activate HTTP Flood Protection"
+                },
+                "ActivateScansProbesProtectionParam": {
+                    "default": "Activate Scanner & Probe Protection"
+                },
+                "ActivateReputationListsProtectionParam": {
+                    "default": "Activate Reputation List Protection"
+                },
+                "ActivateBadBotProtectionParam": {
+                    "default": "Activate Bad Bot Protection"
+                },
+                "AccessLogBucket": {
+                    "default": "ALB Access Log Bucket Name"
+                },
+                "SendAnonymousUsageData": {
+                    "default": "Send Anonymous Usage Data"
+                },
+                "RequestThreshold": {
+                    "default": "Request Threshold"
+                },
+                "ErrorThreshold": {
+                    "default": "Error Threshold"
+                },
+                "WAFBlockPeriod": {
+                    "default": "WAF Block Period"
+                }
+            }
+        }
+    },
+    "Parameters": {
+        "ApplicationLoadBalancerArn": {
+            "Type": "String",
+            "Description": "The Arn of the application load balancer to associate with the Web ACL",
+            "Default": ""
         },
-        "Parameters": ["SqlInjectionProtectionParam", "CrossSiteScriptingProtectionParam", "ActivateHttpFloodProtectionParam", "ActivateScansProbesProtectionParam", "ActivateReputationListsProtectionParam", "ActivateBadBotProtectionParam"]
-      }, {
-        "Label": {
-          "default": "Settings"
+        "RuleAction": {
+            "Type": "String",
+            "Description": "The action to carry out if a request matches the configured rules. Set to COUNT for testing.",
+            "Default": "BLOCK",
+            "AllowedValues": [
+                "ALLOW",
+                "COUNT",
+                "BLOCK"
+            ]
         },
-        "Parameters": ["AccessLogBucket"]
-      }, {
-        "Label": {
-          "default": "Advanced Settings"
-        },
-        "Parameters": ["RequestThreshold", "ErrorThreshold", "WAFBlockPeriod"]
-      }, {
-        "Label": {
-          "default": "Anonymous Metrics Request"
-        },
-        "Parameters": ["SendAnonymousUsageData"]
-      }],
-      "ParameterLabels": {
         "SqlInjectionProtectionParam": {
-          "default": "Activate SQL Injection Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common SQL injection attacks."
         },
         "CrossSiteScriptingProtectionParam": {
-          "default": "Activate Cross-site Scripting Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common XSS attacks."
         },
         "ActivateHttpFloodProtectionParam": {
-          "default": "Activate HTTP Flood Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block HTTP flood attacks."
         },
         "ActivateScansProbesProtectionParam": {
-          "default": "Activate Scanner & Probe Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block scanners and probes."
         },
         "ActivateReputationListsProtectionParam": {
-          "default": "Activate Reputation List Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats)."
         },
         "ActivateBadBotProtectionParam": {
-          "default": "Activate Bad Bot Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block bad bots and content scrapers."
         },
         "AccessLogBucket": {
-          "default": "ALB Access Log Bucket Name"
+            "Type": "String",
+            "Default": "",
+            "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
+            "Description": "Enter a name for the Amazon S3 bucket where you want to store Amazon ALB access logs. This can be the name of either an existing S3 bucket, or a new bucket that the template will create during stack launch (if it does not find a matching bucket name). The solution will modify the bucket\u00e2\u20ac\u2122s notification configuration to trigger the Log Parser AWS Lambda function whenever a new log file is saved in this bucket. More about bucket name restriction here: http://amzn.to/1p1YlU5"
         },
         "SendAnonymousUsageData": {
-          "default": "Send Anonymous Usage Data"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Send anonymous data to AWS to help us understand solution usage across our customer base as a whole. To opt out of this feature, select No."
         },
         "RequestThreshold": {
-          "default": "Request Threshold"
+            "Type": "Number",
+            "Default": "2000",
+            "MinValue": "2000",
+            "Description": "If you chose yes for the Activate HTTP Flood Protection parameter, enter the maximum acceptable requests per FIVE-minute period per IP address. Minimum value of 2000. If you chose to deactivate this protection, ignore this parameter."
         },
         "ErrorThreshold": {
-          "default": "Error Threshold"
+            "Type": "Number",
+            "Default": "50",
+            "MinValue": "0",
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter the maximum acceptable bad requests per minute per IP. If you chose to deactivate Scanners & Probes protection, ignore this parameter."
         },
         "WAFBlockPeriod": {
-          "default": "WAF Block Period"
+            "Type": "Number",
+            "Default": "240",
+            "MinValue": "0",
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate this protection, ignore this parameter."
         }
-      }
-    }
-  },
-
-
-  "Parameters": {
-    "SqlInjectionProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block common SQL injection attacks."
     },
-    "CrossSiteScriptingProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block common XSS attacks."
-    },
-    "ActivateHttpFloodProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block HTTP flood attacks."
-    },
-    "ActivateScansProbesProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block scanners and probes."
-    },
-    "ActivateReputationListsProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats)."
-    },
-    "ActivateBadBotProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block bad bots and content scrapers."
-    },
-    "AccessLogBucket": {
-      "Type": "String",
-      "Default": "",
-      "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
-      "Description": "Enter a name for the Amazon S3 bucket where you want to store Amazon ALB access logs. This can be the name of either an existing S3 bucket, or a new bucket that the template will create during stack launch (if it does not find a matching bucket name). The solution will modify the bucket’s notification configuration to trigger the Log Parser AWS Lambda function whenever a new log file is saved in this bucket. More about bucket name restriction here: http://amzn.to/1p1YlU5"
-    },
-    "SendAnonymousUsageData": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Send anonymous data to AWS to help us understand solution usage across our customer base as a whole. To opt out of this feature, select No."
-    },
-    "RequestThreshold": {
-      "Type": "Number",
-      "Default": "2000",
-      "MinValue": "2000",
-      "Description": "If you chose yes for the Activate HTTP Flood Protection parameter, enter the maximum acceptable requests per FIVE-minute period per IP address. Minimum value of 2000. If you chose to deactivate this protection, ignore this parameter."
-    },
-    "ErrorThreshold": {
-      "Type": "Number",
-      "Default": "50",
-      "MinValue": "0",
-      "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter the maximum acceptable bad requests per minute per IP. If you chose to deactivate Scanners & Probes protection, ignore this parameter."
-    },
-    "WAFBlockPeriod": {
-      "Type": "Number",
-      "Default": "240",
-      "MinValue": "0",
-      "Description": "If you chose yes for the Activate Scanners & Probes Protection parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate this protection, ignore this parameter."
-    }
-  },
-
-
-  "Conditions": {
-    "SqlInjectionProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "SqlInjectionProtectionParam"
-      }, "yes"]
-    },
-    "CrossSiteScriptingProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "CrossSiteScriptingProtectionParam"
-      }, "yes"]
-    },
-    "HttpFloodProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateHttpFloodProtectionParam"
-      }, "yes"]
-    },
-    "ScansProbesProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateScansProbesProtectionParam"
-      }, "yes"]
-    },
-    "ReputationListsProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateReputationListsProtectionParam"
-      }, "yes"]
-    },
-    "BadBotProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateBadBotProtectionParam"
-      }, "yes"]
-    },
-    "LogParserActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateScansProbesProtectionParam"
-      }, "yes"]
-    },
-    "CreateWebACL": {
-      "Fn::Or": [{
-        "Condition": "SqlInjectionProtectionActivated"
-      }, {
-        "Condition": "CrossSiteScriptingProtectionActivated"
-      }, {
-        "Condition": "HttpFloodProtectionActivated"
-      }, {
-        "Condition": "ScansProbesProtectionActivated"
-      }, {
-        "Condition": "ReputationListsProtectionActivated"
-      }, {
-        "Condition": "BadBotProtectionActivated"
-      }]
-    }
-  },
-  "Resources": {
-    "WAFWhitelistSet": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "CreateWebACL",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Whitelist Set"]]
-        }
-      }
-    },
-    "WAFBlacklistSet": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Blacklist Set"]]
-        }
-      }
-    },
-    "WAFScansProbesSet": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Scans Probes Set"]]
-        }
-      }
-    },
-    "WAFReputationListsSet1": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Reputation Lists Set #1"]]
-        }
-      }
-    },
-    "WAFReputationListsSet2": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Reputation Lists Set #2"]]
-        }
-      }
-    },
-    "WAFBadBotSet": {
-      "Type": "AWS::WAFRegional::IPSet",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Bad Bot Set"]]
-        }
-      }
-    },
-    "WAFSqlInjectionDetection": {
-      "Type": "AWS::WAFRegional::SqlInjectionMatchSet",
-      "Condition": "SqlInjectionProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "SQL injection Detection"]]
-        },
-        "SqlInjectionMatchTuples": [{
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Authorization"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Authorization"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }]
-      }
-    },
-    "WAFXssDetection": {
-      "Type": "AWS::WAFRegional::XssMatchSet",
-      "Condition": "CrossSiteScriptingProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "XSS Detection Detection"]]
-        },
-        "XssMatchTuples": [{
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }]
-      }
-    },
-    "WAFWhitelistRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "CreateWebACL",
-      "DependsOn": "WAFWhitelistSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Whitelist Rule"]]
-        },
-        "MetricName": "SecurityAutomationsWhitelistRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFWhitelistSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFBlacklistRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "LogParserActivated",
-      "DependsOn": "WAFBlacklistSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Blacklist Rule"]]
-        },
-        "MetricName": "SecurityAutomationsBlacklistRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFBlacklistSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFScansProbesRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "LogParserActivated",
-      "DependsOn": "WAFScansProbesSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Scans Probes Rule"]]
-        },
-        "MetricName": "SecurityAutomationsScansProbesRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFScansProbesSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFIPReputationListsRule1": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "WAFReputationListsSet1",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "WAF IP Reputation Lists Rule #1"]]
-        },
-        "MetricName": "SecurityAutomationsIPReputationListsRule1",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFReputationListsSet1"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFIPReputationListsRule2": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "WAFReputationListsSet2",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "WAF IP Reputation Lists Rule #2"]]
-        },
-        "MetricName": "SecurityAutomationsIPReputationListsRule2",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFReputationListsSet2"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFBadBotRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "WAFBadBotSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Bad Bot Rule"]]
-        },
-        "MetricName": "SecurityAutomationsBadBotRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFBadBotSet"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFSqlInjectionRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "SqlInjectionProtectionActivated",
-      "DependsOn": "WAFSqlInjectionDetection",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "SQL Injection Rule"]]
-        },
-        "MetricName": "SecurityAutomationsSqlInjectionRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFSqlInjectionDetection"
-          },
-          "Negated": false,
-          "Type": "SqlInjectionMatch"
-        }]
-      }
-    },
-    "WAFXssRule": {
-      "Type": "AWS::WAFRegional::Rule",
-      "Condition": "CrossSiteScriptingProtectionActivated",
-      "DependsOn": "WAFXssDetection",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "XSS Rule"]]
-        },
-        "MetricName": "SecurityAutomationsXssRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFXssDetection"
-          },
-          "Negated": false,
-          "Type": "XssMatch"
-        }]
-      }
-    },
-    "WAFWebACL": {
-      "Type": "AWS::WAFRegional::WebACL",
-      "Condition": "CreateWebACL",
-      "DependsOn": ["WAFWhitelistRule"],
-      "Properties": {
-        "Name": {
-          "Ref": "AWS::StackName"
-        },
-        "DefaultAction": {
-          "Type": "ALLOW"
-        },
-        "MetricName": "SecurityAutomationsMaliciousRequesters",
-        "Rules": [{
-          "Action": {
-            "Type": "ALLOW"
-          },
-          "Priority": 10,
-          "RuleId": {
-            "Ref": "WAFWhitelistRule"
-          }
-        }]
-      }
-    },
-    "LambdaRoleLogParser": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "S3Access",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "s3:GetObject",
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }, "/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "S3AccessPut",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "s3:PutObject",
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }, "/aws-waf-security-automations-current-blocked-ips.json"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf-regional:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetIPSet",
-                "waf-regional:UpdateIPSet"
-              ],
-              "Resource": [{
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf-regional:", {
-                      "Ref": "AWS::Region"
-                    }, ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFBlacklistSet"
-                    }
-                  ]
-                ]
-              }, {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf-regional:", {
-                      "Ref": "AWS::Region"
-                    }, ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFScansProbesSet"
-                    }
-                  ]
-                ]
-              }]
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFLogParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "LogParserActivated",
-      "DependsOn": ["LambdaRoleLogParser", "WAFBlacklistSet", "WAFScansProbesSet"],
-      "Properties": {
-        "Description": {
-          "Fn::Join": ["", [
-            "This function parses ALB access logs to identify suspicious behavior, such as an abnormal amount of errors. It then blocks those IP addresses for a customer-defined period of time. Parameters: ", {
-              "Ref": "ErrorThreshold"
-            },
-            ",", {
-              "Ref": "WAFBlockPeriod"
-            },
-            "."
-          ]]
-        },
-        "Handler": "log-parser.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleLogParser", "Arn"]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v2/log-parser.zip"
-        },
-        "Environment": {
-          "Variables": {
-            "OUTPUT_BUCKET": {
-              "Ref": "AccessLogBucket"
-            },
-            "IP_SET_ID_BLACKLIST": {
-              "Ref": "WAFBlacklistSet"
-            },
-            "IP_SET_ID_AUTO_BLOCK": {
-              "Ref": "WAFScansProbesSet"
-            },
-            "BLACKLIST_BLOCK_PERIOD": {
-              "Ref": "WAFBlockPeriod"
-            },
-            "ERROR_PER_MINUTE_LIMIT": {
-              "Ref": "ErrorThreshold"
-            },
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            },
-            "LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION": "10000",
-            "MAX_AGE_TO_UPDATE": "30",
-            "REGION": {
-              "Ref": "AWS::Region"
-            },
-            "LOG_TYPE": "alb"
-          }
-        },
-        "Runtime": "python2.7",
-        "MemorySize": "512",
-        "Timeout": "300"
-      }
-    },
-    "LambdaInvokePermissionLogParser": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "LogParserActivated",
-      "DependsOn": "LambdaWAFLogParserFunction",
-      "Properties": {
-        "FunctionName": {
-          "Fn::GetAtt": ["LambdaWAFLogParserFunction", "Arn"]
-        },
-        "Action": "lambda:*",
-        "Principal": "s3.amazonaws.com",
-        "SourceAccount": {
-          "Ref": "AWS::AccountId"
-        }
-      }
-    },
-    "LambdaRoleReputationListsParser": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Policies": [{
-          "PolicyName": "CloudWatchLogs",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf-regional:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetIPSet",
-                "waf-regional:UpdateIPSet"
-              ],
-              "Resource": [{
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf-regional:", {
-                      "Ref": "AWS::Region"
-                    }, ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFReputationListsSet1"
-                    }
-                  ]
-                ]
-              }, {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf-regional:", {
-                      "Ref": "AWS::Region"
-                    }, ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFReputationListsSet2"
-                    }
-                  ]
-                ]
-              }]
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFReputationListsParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "LambdaRoleReputationListsParser",
-      "Properties": {
-        "Description": "This lambda function checks third-party IP reputation lists hourly for new IP ranges to block. These lists include the Spamhaus Dont Route Or Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats IP list, and the Tor exit node list.",
-        "Handler": "reputation-lists-parser.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "LambdaRoleReputationListsParser",
-            "Arn"
-          ]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v3/reputation-lists-parser.zip"
-        },
-        "Runtime": "nodejs6.10",
-        "MemorySize": "128",
-        "Timeout": "300",
-        "Environment": {
-          "Variables": {
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            }
-          }
-        }
-      }
-    },
-    "LambdaWAFReputationListsParserEventsRule": {
-      "Type": "AWS::Events::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": ["LambdaWAFReputationListsParserFunction", "WAFReputationListsSet1", "WAFReputationListsSet2"],
-      "Properties": {
-        "Description": "Security Automations - WAF Reputation Lists",
-        "ScheduleExpression": "rate(1 hour)",
-        "Targets": [{
-          "Arn": {
-            "Fn::GetAtt": [
-              "LambdaWAFReputationListsParserFunction",
-              "Arn"
-            ]
-          },
-          "Id": "LambdaWAFReputationListsParserFunction",
-          "Input": {
-            "Fn::Join": [
-              "", [
-                "{\"lists\":",
-                "[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}]",
-                ",\"logType\":\"alb\"",
-                ",\"region\":\"", {
-                  "Ref": "AWS::Region"
-                }, "\",",
-                "\"ipSetIds\": [",
-                "\"", {
-                  "Ref": "WAFReputationListsSet1"
-                },
-                "\",",
-                "\"", {
-                  "Ref": "WAFReputationListsSet2"
-                },
-                "\"",
-                "]}"
-              ]
-            ]
-          }
-        }]
-      }
-    },
-    "LambdaInvokePermissionReputationListsParser": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": ["LambdaWAFReputationListsParserFunction", "LambdaWAFReputationListsParserEventsRule"],
-      "Properties": {
-        "FunctionName": {
-          "Ref": "LambdaWAFReputationListsParserFunction"
-        },
-        "Action": "lambda:InvokeFunction",
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "LambdaWAFReputationListsParserEventsRule",
-            "Arn"
-          ]
-        }
-      }
-    },
-    "LambdaRoleBadBot": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf-regional:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetIPSet",
-                "waf-regional:UpdateIPSet"
-              ],
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf-regional:", {
-                      "Ref": "AWS::Region"
-                    }, ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFBadBotSet"
-                    }
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFBadBotParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "LambdaRoleBadBot",
-      "Properties": {
-        "Description": "This lambda function will intercepts and inspects trap endpoint requests to extract its IP address, and then add it to an AWS WAF block list.",
-        "Handler": "access-handler.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleBadBot", "Arn"]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v2/access-handler.zip"
-        },
-        "Environment": {
-          "Variables": {
-            "IP_SET_ID_BAD_BOT": {
-              "Ref": "WAFBadBotSet"
-            },
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            },
-            "REGION": {
-              "Ref": "AWS::Region"
-            },
-            "LOG_TYPE": "alb"
-          }
-        },
-        "Runtime": "python2.7",
-        "MemorySize": "128",
-        "Timeout": "300"
-      }
-    },
-    "LambdaInvokePermissionBadBot": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "LambdaWAFBadBotParserFunction",
-      "Properties": {
-        "FunctionName": {
-          "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
-        },
-        "Action": "lambda:*",
-        "Principal": "apigateway.amazonaws.com"
-      }
-    },
-    "ApiGatewayBadBot": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "Name": "Security Automations - WAF Bad Bot API",
-        "Description": "API created by AWS WAF Security Automations CloudFormation template. This endpoint will be used to capture bad bots."
-      }
-    },
-    "ApiGatewayBadBotResource": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "ParentId": {
-          "Fn::GetAtt": ["ApiGatewayBadBot", "RootResourceId"]
-        },
-        "PathPart": "{proxy+}"
-      }
-    },
-    "ApiGatewayBadBotMethodRoot": {
-      "Type": "AWS::ApiGateway::Method",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": ["LambdaWAFBadBotParserFunction", "LambdaInvokePermissionBadBot", "ApiGatewayBadBot"],
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "ResourceId": {
-          "Fn::GetAtt": ["ApiGatewayBadBot", "RootResourceId"]
-        },
-        "HttpMethod": "ANY",
-        "AuthorizationType": "NONE",
-        "RequestParameters": {
-          "method.request.header.X-Forwarded-For": false
-        },
-        "Integration": {
-          "Type": "AWS_PROXY",
-          "IntegrationHttpMethod": "POST",
-          "Uri": {
-            "Fn::Join": ["", [
-              "arn:aws:apigateway:", {
-                "Ref": "AWS::Region"
-              },
-              ":lambda:path/2015-03-31/functions/", {
-                "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
-              },
-              "/invocations"
-            ]]
-          }
-        }
-      }
-    },
-    "ApiGatewayBadBotMethod": {
-      "Type": "AWS::ApiGateway::Method",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": ["LambdaWAFBadBotParserFunction", "LambdaInvokePermissionBadBot", "ApiGatewayBadBot"],
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "ResourceId": {
-          "Ref": "ApiGatewayBadBotResource"
-        },
-        "HttpMethod": "ANY",
-        "AuthorizationType": "NONE",
-        "RequestParameters": {
-          "method.request.header.X-Forwarded-For": false
-        },
-        "Integration": {
-          "Type": "AWS_PROXY",
-          "IntegrationHttpMethod": "POST",
-          "Uri": {
-            "Fn::Join": ["", [
-              "arn:aws:apigateway:", {
-                "Ref": "AWS::Region"
-              },
-              ":lambda:path/2015-03-31/functions/", {
-                "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
-              },
-              "/invocations"
-            ]]
-          }
-        }
-      }
-    },
-    "ApiGatewayBadBotDeployment": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "ApiGatewayBadBotMethod",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "Description": "CloudFormation Deployment Stage",
-        "StageName": "CFDeploymentStage"
-      }
-    },
-    "ApiGatewayBadBotStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "ApiGatewayBadBotDeployment",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ApiGatewayBadBotDeployment"
-        },
-        "Description": "Production Stage",
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "StageName": "ProdStage"
-      }
-    },
-    "LambdaRoleCustomResource": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "CreateWebACL",
-      "DependsOn": "WAFWebACL",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "S3Access",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "s3:CreateBucket",
-                "s3:GetBucketLocation",
-                "s3:GetBucketNotification",
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:PutBucketNotification"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }]]
-              }
-            }]
-          }
-        }, {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "PolicyName": "LambdaAccess",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [{
-                "Effect": "Allow",
-                "Action": "lambda:InvokeFunction",
-                "Resource": {
-                  "Fn::GetAtt": ["LambdaWAFReputationListsParserFunction", "Arn"]
+    "Conditions": {
+        "AssociateWithALB": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "ApplicationLoadBalancerArn"
+                        },
+                        ""
+                    ]
                 }
-              }]
-            }
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
-        }, {
-          "PolicyName": "WAFAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetWebACL",
-                "waf-regional:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf-regional:", {
-                    "Ref": "AWS::Region"
-                  }, ":", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":webacl/", {
+            ]
+        },
+        "SqlInjectionProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "SqlInjectionProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "CrossSiteScriptingProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "CrossSiteScriptingProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "HttpFloodProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "ScansProbesProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "ReputationListsProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "BadBotProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "LogParserActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "yes"
+            ]
+        },
+        "CreateWebACL": {
+            "Fn::Or": [
+                {
+                    "Condition": "SqlInjectionProtectionActivated"
+                },
+                {
+                    "Condition": "CrossSiteScriptingProtectionActivated"
+                },
+                {
+                    "Condition": "HttpFloodProtectionActivated"
+                },
+                {
+                    "Condition": "ScansProbesProtectionActivated"
+                },
+                {
+                    "Condition": "ReputationListsProtectionActivated"
+                },
+                {
+                    "Condition": "BadBotProtectionActivated"
+                }
+            ]
+        }
+    },
+    "Resources": {
+        "WebAclAssociation": {
+            "Type": "AWS::WAFRegional::WebACLAssociation",
+            "Condition": "AssociateWithALB",
+            "Properties": {
+                "ResourceArn": {
+                    "Ref": "ApplicationLoadBalancerArn"
+                },
+                "WebACLId": {
                     "Ref": "WAFWebACL"
-                  }
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFRuleAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetRule",
-                "waf-regional:GetIPSet",
-                "waf-regional:UpdateIPSet",
-                "waf-regional:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf-regional:", {
-                    "Ref": "AWS::Region"
-                  }, ":", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":rule/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFIPSetAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetIPSet",
-                "waf-regional:UpdateIPSet"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf-regional:", {
-                    "Ref": "AWS::Region"
-                  }, ":", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":ipset/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFRateBasedRuleAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf-regional:GetRateBasedRule",
-                "waf-regional:CreateRateBasedRule",
-                "waf-regional:DeleteRateBasedRule",
-                "waf-regional:ListRateBasedRules",
-                "waf-regional:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf-regional:", {
-                    "Ref": "AWS::Region"
-                  }, ":", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":ratebasedrule/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf-regional:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFCustomResourceFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "CreateWebACL",
-      "DependsOn": "LambdaRoleCustomResource",
-      "Properties": {
-        "Description": "This lambda function configures the Web ACL rules based on the features enabled in the CloudFormation template.",
-        "Handler": "custom-resource.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleCustomResource", "Arn"]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v4/custom-resource.zip"
-        },
-        "Runtime": "python2.7",
-        "MemorySize": "128",
-        "Timeout": "300"
-      }
-    },
-    "WafWebAclRuleControler": {
-      "Type": "Custom::WafWebAclRuleControler",
-      "Condition": "CreateWebACL",
-      "DependsOn": ["LambdaWAFCustomResourceFunction", "WAFWebACL"],
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": ["LambdaWAFCustomResourceFunction", "Arn"]
-        },
-        "StackName": {
-          "Ref": "AWS::StackName"
-        },
-        "WAFWebACL": {
-          "Ref": "WAFWebACL"
-        },
-        "Region": {
-          "Ref": "AWS::Region"
-        },
-        "LambdaWAFReputationListsParserFunction": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Fn::GetAtt": ["LambdaWAFReputationListsParserFunction", "Arn"]
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+                }
+            }
         },
         "WAFWhitelistSet": {
-          "Ref": "WAFWhitelistSet"
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "CreateWebACL",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Whitelist Set"
+                }
+            }
         },
         "WAFBlacklistSet": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFBlacklistSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Blacklist Set"
+                }
+            }
         },
         "WAFScansProbesSet": {
-          "Fn::If": ["ScansProbesProtectionActivated", {
-            "Ref": "WAFScansProbesSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Scans Probes Set"
+                }
+            }
         },
         "WAFReputationListsSet1": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFReputationListsSet1"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Reputation Lists Set #1"
+                }
+            }
         },
         "WAFReputationListsSet2": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFReputationListsSet2"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Reputation Lists Set #2"
+                }
+            }
         },
         "WAFBadBotSet": {
-          "Fn::If": ["BadBotProtectionActivated", {
-            "Ref": "WAFBadBotSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::IPSet",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Bad Bot Set"
+                }
+            }
         },
-        "AccessLogBucket": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "AccessLogBucket"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+        "WAFSqlInjectionDetection": {
+            "Type": "AWS::WAFRegional::SqlInjectionMatchSet",
+            "Condition": "SqlInjectionProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - SQL injection Detection"
+                },
+                "SqlInjectionMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Authorization"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Authorization"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    }
+                ]
+            }
         },
-        "LambdaWAFLogParserFunction": {
-          "Fn::If": ["LogParserActivated", {
-            "Fn::GetAtt": ["LambdaWAFLogParserFunction", "Arn"]
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+        "WAFXssDetection": {
+            "Type": "AWS::WAFRegional::XssMatchSet",
+            "Condition": "CrossSiteScriptingProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - XSS Detection Detection"
+                },
+                "XssMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    }
+                ]
+            }
         },
         "WAFWhitelistRule": {
-          "Fn::If": ["CreateWebACL", {
-            "Ref": "WAFWhitelistRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "CreateWebACL",
+            "DependsOn": "WAFWhitelistSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Whitelist Rule"
+                },
+                "MetricName": "SecurityAutomationsWhitelistRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFWhitelistSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFBlacklistRule": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFBlacklistRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "LogParserActivated",
+            "DependsOn": "WAFBlacklistSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Blacklist Rule"
+                },
+                "MetricName": "SecurityAutomationsBlacklistRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFScansProbesRule": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFScansProbesRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "LogParserActivated",
+            "DependsOn": "WAFScansProbesSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Scans Probes Rule"
+                },
+                "MetricName": "SecurityAutomationsScansProbesRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFIPReputationListsRule1": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFIPReputationListsRule1"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "WAFReputationListsSet1",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - WAF IP Reputation Lists Rule #1"
+                },
+                "MetricName": "SecurityAutomationsIPReputationListsRule1",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFReputationListsSet1"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": false
+                    }
+                ]
+            }
         },
         "WAFIPReputationListsRule2": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFIPReputationListsRule2"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "WAFReputationListsSet2",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - WAF IP Reputation Lists Rule #2"
+                },
+                "MetricName": "SecurityAutomationsIPReputationListsRule2",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFReputationListsSet2"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": false
+                    }
+                ]
+            }
         },
         "WAFBadBotRule": {
-          "Fn::If": ["BadBotProtectionActivated", {
-            "Ref": "WAFBadBotRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "WAFBadBotSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Bad Bot Rule"
+                },
+                "MetricName": "SecurityAutomationsBadBotRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": false
+                    }
+                ]
+            }
         },
         "WAFSqlInjectionRule": {
-          "Fn::If": ["SqlInjectionProtectionActivated", {
-            "Ref": "WAFSqlInjectionRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "SqlInjectionProtectionActivated",
+            "DependsOn": "WAFSqlInjectionDetection",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - SQL Injection Rule"
+                },
+                "MetricName": "SecurityAutomationsSqlInjectionRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFSqlInjectionDetection"
+                        },
+                        "Negated": false,
+                        "Type": "SqlInjectionMatch"
+                    }
+                ]
+            }
         },
         "WAFXssRule": {
-          "Fn::If": ["CrossSiteScriptingProtectionActivated", {
-            "Ref": "WAFXssRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAFRegional::Rule",
+            "Condition": "CrossSiteScriptingProtectionActivated",
+            "DependsOn": "WAFXssDetection",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - XSS Rule"
+                },
+                "MetricName": "SecurityAutomationsXssRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFXssDetection"
+                        },
+                        "Negated": false,
+                        "Type": "XssMatch"
+                    }
+                ]
+            }
         },
-        "SqlInjectionProtection": {
-          "Ref": "SqlInjectionProtectionParam"
+        "WAFWebACL": {
+            "Type": "AWS::WAFRegional::WebACL",
+            "Condition": "CreateWebACL",
+            "DependsOn": [
+                "WAFWhitelistRule"
+            ],
+            "Properties": {
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "DefaultAction": {
+                    "Type": "ALLOW"
+                },
+                "MetricName": "SecurityAutomationsMaliciousRequesters",
+                "Rules": [
+                    {
+                        "Action": {
+                            "Type": "ALLOW"
+                        },
+                        "Priority": 10,
+                        "RuleId": {
+                            "Ref": "WAFWhitelistRule"
+                        }
+                    }
+                ]
+            }
         },
-        "CrossSiteScriptingProtection": {
-          "Ref": "CrossSiteScriptingProtectionParam"
+        "LambdaRoleLogParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:GetObject",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "S3AccessPut",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:PutObject",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}/aws-waf-security-automations-current-blocked-ips.json"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf-regional:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetIPSet",
+                                        "waf-regional:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFBlacklistSet}"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFScansProbesSet}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         },
-        "ActivateHttpFloodProtection": {
-          "Ref": "ActivateHttpFloodProtectionParam"
+        "LambdaWAFLogParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "LogParserActivated",
+            "DependsOn": [
+                "LambdaRoleLogParser",
+                "WAFBlacklistSet",
+                "WAFScansProbesSet"
+            ],
+            "Properties": {
+                "Description": {
+                    "Fn::Sub": "This function parses ALB access logs to identify suspicious behavior, such as an abnormal amount of errors. It then blocks those IP addresses for a customer-defined period of time. Parameters: ${ErrorThreshold},${WAFBlockPeriod}."
+                },
+                "Handler": "log-parser.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleLogParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v2/log-parser.zip"
+                },
+                "Environment": {
+                    "Variables": {
+                        "OUTPUT_BUCKET": {
+                            "Ref": "AccessLogBucket"
+                        },
+                        "IP_SET_ID_BLACKLIST": {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        "IP_SET_ID_AUTO_BLOCK": {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        "BLACKLIST_BLOCK_PERIOD": {
+                            "Ref": "WAFBlockPeriod"
+                        },
+                        "ERROR_PER_MINUTE_LIMIT": {
+                            "Ref": "ErrorThreshold"
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION": "10000",
+                        "MAX_AGE_TO_UPDATE": "30",
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "LOG_TYPE": "alb"
+                    }
+                },
+                "Runtime": "python2.7",
+                "MemorySize": 512,
+                "Timeout": 300
+            }
         },
-        "ActivateScansProbesProtection": {
-          "Ref": "ActivateScansProbesProtectionParam"
-        },
-        "ActivateReputationListsProtection": {
-          "Ref": "ActivateReputationListsProtectionParam"
-        },
-        "ActivateBadBotProtection": {
-          "Ref": "ActivateBadBotProtectionParam"
-        },
-        "RequestThreshold": {
-          "Ref": "RequestThreshold"
-        },
-        "ErrorThreshold": {
-          "Ref": "ErrorThreshold"
-        },
-        "WAFBlockPeriod": {
-          "Ref": "WAFBlockPeriod"
-        },
-        "SendAnonymousUsageData": {
-          "Ref": "SendAnonymousUsageData"
-        },
-        "UUID": {
-          "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-        },
-        "LOG_TYPE": "alb"
-      }
-    },
-    "SolutionHelperRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": "lambda.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "Solution_Helper_Permissions",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }]
-      }
-    },
-    "SolutionHelper": {
-      "Type": "AWS::Lambda::Function",
-      "DependsOn": "SolutionHelperRole",
-      "Properties": {
-        "Handler": "solution-helper.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "SolutionHelperRole",
-            "Arn"
-          ]
-        },
-        "Description": "This lambda function executes generic common tasks to support this solution.",
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": [
-              "", [
-                "solutions-", {
-                  "Ref": "AWS::Region"
+        "LambdaInvokePermissionLogParser": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "LogParserActivated",
+            "DependsOn": "LambdaWAFLogParserFunction",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFLogParserFunction",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:*",
+                "Principal": "s3.amazonaws.com",
+                "SourceAccount": {
+                    "Ref": "AWS::AccountId"
                 }
-              ]
-            ]
-          },
-          "S3Key": "library/solution-helper/v1/solution-helper.zip"
+            }
         },
-        "Runtime": "python2.7",
-        "Timeout": "300"
-      }
+        "LambdaRoleReputationListsParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "CloudWatchLogs",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf-regional:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetIPSet",
+                                        "waf-regional:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFReputationListsSet1}"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFReputationListsSet2}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFReputationListsParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "LambdaRoleReputationListsParser",
+            "Properties": {
+                "Description": "This lambda function checks third-party IP reputation lists hourly for new IP ranges to block. These lists include the Spamhaus Dont Route Or Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats IP list, and the Tor exit node list.",
+                "Handler": "reputation-lists-parser.handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleReputationListsParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v3/reputation-lists-parser.zip"
+                },
+                "Runtime": "nodejs6.10",
+                "MemorySize": 128,
+                "Timeout": 300,
+                "Environment": {
+                    "Variables": {
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "LambdaWAFReputationListsParserEventsRule": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFReputationListsParserFunction",
+                "WAFReputationListsSet1",
+                "WAFReputationListsSet2"
+            ],
+            "Properties": {
+                "Description": "Security Automations - WAF Reputation Lists",
+                "ScheduleExpression": "rate(1 hour)",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "LambdaWAFReputationListsParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "LambdaWAFReputationListsParserFunction",
+                        "Input": {
+                            "Fn::Sub": "{\"lists\":[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}],\"logType\":\"alb\",\"region\":\"${AWS::Region}\",\"ipSetIds\": [\"${WAFReputationListsSet1}\",\"${WAFReputationListsSet2}\"]}"
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaInvokePermissionReputationListsParser": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFReputationListsParserFunction",
+                "LambdaWAFReputationListsParserEventsRule"
+            ],
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "LambdaWAFReputationListsParserFunction"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFReputationListsParserEventsRule",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaRoleBadBot": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf-regional:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetIPSet",
+                                        "waf-regional:UpdateIPSet"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFBadBotSet}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFBadBotParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaRoleBadBot",
+            "Properties": {
+                "Description": "This lambda function will intercepts and inspects trap endpoint requests to extract its IP address, and then add it to an AWS WAF block list.",
+                "Handler": "access-handler.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleBadBot",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v2/access-handler.zip"
+                },
+                "Environment": {
+                    "Variables": {
+                        "IP_SET_ID_BAD_BOT": {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "LOG_TYPE": "alb"
+                    }
+                },
+                "Runtime": "python2.7",
+                "MemorySize": 128,
+                "Timeout": 300
+            }
+        },
+        "LambdaInvokePermissionBadBot": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaWAFBadBotParserFunction",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFBadBotParserFunction",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:*",
+                "Principal": "apigateway.amazonaws.com"
+            }
+        },
+        "ApiGatewayBadBot": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "Name": "Security Automations - WAF Bad Bot API",
+                "Description": "API created by AWS WAF Security Automations CloudFormation template. This endpoint will be used to capture bad bots."
+            }
+        },
+        "ApiGatewayBadBotResource": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ParentId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "PathPart": "{proxy+}"
+            }
+        },
+        "ApiGatewayBadBotMethodRoot": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFBadBotParserFunction",
+                "LambdaInvokePermissionBadBot",
+                "ApiGatewayBadBot"
+            ],
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations"
+                    }
+                }
+            }
+        },
+        "ApiGatewayBadBotMethod": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFBadBotParserFunction",
+                "LambdaInvokePermissionBadBot",
+                "ApiGatewayBadBot"
+            ],
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Ref": "ApiGatewayBadBotResource"
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations"
+                    }
+                }
+            }
+        },
+        "ApiGatewayBadBotDeployment": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "ApiGatewayBadBotMethod",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "Description": "CloudFormation Deployment Stage",
+                "StageName": "CFDeploymentStage"
+            }
+        },
+        "ApiGatewayBadBotStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "ApiGatewayBadBotDeployment",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "ApiGatewayBadBotDeployment"
+                },
+                "Description": "Production Stage",
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "StageName": "ProdStage"
+            }
+        },
+        "LambdaRoleCustomResource": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "CreateWebACL",
+            "DependsOn": "WAFWebACL",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:CreateBucket",
+                                        "s3:GetBucketLocation",
+                                        "s3:GetBucketNotification",
+                                        "s3:GetObject",
+                                        "s3:ListBucket",
+                                        "s3:PutBucketNotification"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "ReputationListsProtectionActivated",
+                            {
+                                "PolicyName": "LambdaAccess",
+                                "PolicyDocument": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "lambda:InvokeFunction",
+                                            "Resource": {
+                                                "Fn::GetAtt": [
+                                                    "LambdaWAFReputationListsParserFunction",
+                                                    "Arn"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "WAFAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetWebACL",
+                                        "waf-regional:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:webacl/${WAFWebACL}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFRuleAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetRule",
+                                        "waf-regional:GetIPSet",
+                                        "waf-regional:UpdateIPSet",
+                                        "waf-regional:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:rule/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFIPSetAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetIPSet",
+                                        "waf-regional:UpdateIPSet"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFRateBasedRuleAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf-regional:GetRateBasedRule",
+                                        "waf-regional:CreateRateBasedRule",
+                                        "waf-regional:DeleteRateBasedRule",
+                                        "waf-regional:ListRateBasedRules",
+                                        "waf-regional:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ratebasedrule/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf-regional:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFCustomResourceFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "CreateWebACL",
+            "DependsOn": "LambdaRoleCustomResource",
+            "Properties": {
+                "Description": "This lambda function configures the Web ACL rules based on the features enabled in the CloudFormation template.",
+                "Handler": "custom-resource.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleCustomResource",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v4/custom-resource.zip"
+                },
+                "Runtime": "python2.7",
+                "MemorySize": 128,
+                "Timeout": 300
+            }
+        },
+        "WafWebAclRuleControler": {
+            "Type": "Custom::WafWebAclRuleControler",
+            "Condition": "CreateWebACL",
+            "DependsOn": [
+                "LambdaWAFCustomResourceFunction",
+                "WAFWebACL"
+            ],
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFCustomResourceFunction",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "RuleAction": {
+                    "Ref": "RuleAction"
+                },
+                "WAFWebACL": {
+                    "Ref": "WAFWebACL"
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "LambdaWAFReputationListsParserFunction": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "LambdaWAFReputationListsParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistSet": {
+                    "Ref": "WAFWhitelistSet"
+                },
+                "WAFBlacklistSet": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScansProbesSet": {
+                    "Fn::If": [
+                        "ScansProbesProtectionActivated",
+                        {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSet1": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFReputationListsSet1"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSet2": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFReputationListsSet2"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSet": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "AccessLogBucket": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "AccessLogBucket"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "LambdaWAFLogParserFunction": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "LambdaWAFLogParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistRule": {
+                    "Fn::If": [
+                        "CreateWebACL",
+                        {
+                            "Ref": "WAFWhitelistRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBlacklistRule": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFBlacklistRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScansProbesRule": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFScansProbesRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFIPReputationListsRule1": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFIPReputationListsRule1"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFIPReputationListsRule2": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFIPReputationListsRule2"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotRule": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Ref": "WAFBadBotRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFSqlInjectionRule": {
+                    "Fn::If": [
+                        "SqlInjectionProtectionActivated",
+                        {
+                            "Ref": "WAFSqlInjectionRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFXssRule": {
+                    "Fn::If": [
+                        "CrossSiteScriptingProtectionActivated",
+                        {
+                            "Ref": "WAFXssRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "SqlInjectionProtection": {
+                    "Ref": "SqlInjectionProtectionParam"
+                },
+                "CrossSiteScriptingProtection": {
+                    "Ref": "CrossSiteScriptingProtectionParam"
+                },
+                "ActivateHttpFloodProtection": {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "ActivateScansProbesProtection": {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "ActivateReputationListsProtection": {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "ActivateBadBotProtection": {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "RequestThreshold": {
+                    "Ref": "RequestThreshold"
+                },
+                "ErrorThreshold": {
+                    "Ref": "ErrorThreshold"
+                },
+                "WAFBlockPeriod": {
+                    "Ref": "WAFBlockPeriod"
+                },
+                "SendAnonymousUsageData": {
+                    "Ref": "SendAnonymousUsageData"
+                },
+                "UUID": {
+                    "Fn::GetAtt": [
+                        "CreateUniqueID",
+                        "UUID"
+                    ]
+                },
+                "LOG_TYPE": "alb"
+            }
+        },
+        "SolutionHelperRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "Solution_Helper_Permissions",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "SolutionHelper": {
+            "Type": "AWS::Lambda::Function",
+            "DependsOn": "SolutionHelperRole",
+            "Properties": {
+                "Handler": "solution-helper.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "SolutionHelperRole",
+                        "Arn"
+                    ]
+                },
+                "Description": "This lambda function executes generic common tasks to support this solution.",
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "library/solution-helper/v1/solution-helper.zip"
+                },
+                "Runtime": "python2.7",
+                "Timeout": 300
+            }
+        },
+        "CreateUniqueID": {
+            "Type": "Custom::CreateUUID",
+            "DependsOn": "SolutionHelper",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "SolutionHelper",
+                        "Arn"
+                    ]
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "CreateUniqueID": "true"
+            }
+        }
     },
-    "CreateUniqueID": {
-      "Type": "Custom::CreateUUID",
-      "DependsOn": "SolutionHelper",
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "SolutionHelper",
-            "Arn"
-          ]
+    "Outputs": {
+        "BadBotHoneypotEndpoint": {
+            "Description": "Bad Bot Honeypot Endpoint",
+            "Value": {
+                "Fn::Sub": "https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}"
+            },
+            "Condition": "BadBotProtectionActivated"
         },
-        "Region": {
-          "Ref": "AWS::Region"
-        },
-        "CreateUniqueID": "true"
-      }
+        "WAFWebACL": {
+            "Description": "AWS WAF WebACL ID",
+            "Value": {
+                "Ref": "WAFWebACL"
+            },
+            "Condition": "CreateWebACL"
+        }
     }
-  },
-  "Outputs": {
-    "BadBotHoneypotEndpoint": {
-      "Description": "Bad Bot Honeypot Endpoint",
-      "Value": {
-        "Fn::Join": ["", [
-          "https://", {
-            "Ref": "ApiGatewayBadBot"
-          },
-          ".execute-api.", {
-            "Ref": "AWS::Region"
-          },
-          ".amazonaws.com/", {
-            "Ref": "ApiGatewayBadBotStage"
-          }
-        ]]
-      },
-      "Condition": "BadBotProtectionActivated"
-    },
-    "WAFWebACL": {
-      "Description": "AWS WAF WebACL ID",
-      "Value": {
-        "Ref": "WAFWebACL"
-      },
-      "Condition": "CreateWebACL"
-    }
-  }
 }

--- a/deployment/aws-waf-security-automations-alb.yaml
+++ b/deployment/aws-waf-security-automations-alb.yaml
@@ -1,0 +1,1019 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: '(SO0006-ALB) - AWS WAF Security Automations - ALB v2.1: This AWS CloudFormation
+  template helps you provision the AWS WAF Security Automations stack without worrying
+  about creating and configuring the underlying AWS infrastructure. **WARNING** This
+  template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket,
+  and an Amazon CloudWatch custom metric. You will be billed for the AWS resources
+  used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com,
+  Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software
+  License (the License). You may not use this file except in compliance with the License.
+  A copy of the License is located at http://aws.amazon.com/asl/ or in the license
+  file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the
+  specific language governing permissions and limitations under the License.'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Protection List
+        Parameters:
+          - SqlInjectionProtectionParam
+          - CrossSiteScriptingProtectionParam
+          - ActivateHttpFloodProtectionParam
+          - ActivateScansProbesProtectionParam
+          - ActivateReputationListsProtectionParam
+          - ActivateBadBotProtectionParam
+      - Label:
+          default: Settings
+        Parameters:
+          - AccessLogBucket
+      - Label:
+          default: Advanced Settings
+        Parameters:
+          - RequestThreshold
+          - ErrorThreshold
+          - WAFBlockPeriod
+      - Label:
+          default: Anonymous Metrics Request
+        Parameters:
+          - SendAnonymousUsageData
+    ParameterLabels:
+      SqlInjectionProtectionParam:
+        default: Activate SQL Injection Protection
+      CrossSiteScriptingProtectionParam:
+        default: Activate Cross-site Scripting Protection
+      ActivateHttpFloodProtectionParam:
+        default: Activate HTTP Flood Protection
+      ActivateScansProbesProtectionParam:
+        default: Activate Scanner & Probe Protection
+      ActivateReputationListsProtectionParam:
+        default: Activate Reputation List Protection
+      ActivateBadBotProtectionParam:
+        default: Activate Bad Bot Protection
+      AccessLogBucket:
+        default: ALB Access Log Bucket Name
+      SendAnonymousUsageData:
+        default: Send Anonymous Usage Data
+      RequestThreshold:
+        default: Request Threshold
+      ErrorThreshold:
+        default: Error Threshold
+      WAFBlockPeriod:
+        default: WAF Block Period
+Parameters:
+  ApplicationLoadBalancerArn:
+    Type: String
+    Description: The Arn of the application load balancer to associate with the Web
+      ACL
+    Default: ''
+  RuleAction:
+    Type: String
+    Description: The action to carry out if a request matches the configured rules.
+      Set to COUNT for testing.
+    Default: BLOCK
+    AllowedValues:
+      - ALLOW
+      - COUNT
+      - BLOCK
+  SqlInjectionProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block common SQL injection
+      attacks.
+  CrossSiteScriptingProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block common XSS attacks.
+  ActivateHttpFloodProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block HTTP flood attacks.
+  ActivateScansProbesProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block scanners and
+      probes.
+  ActivateReputationListsProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: 'Choose yes to block requests from IP addresses on third-party reputation
+      lists (supported lists: spamhaus, torproject, and emergingthreats).'
+  ActivateBadBotProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block bad bots and
+      content scrapers.
+  AccessLogBucket:
+    Type: String
+    Default: ''
+    AllowedPattern: (^$|^([a-z]|(\d(?!\d{0,2}\.\d{1,3}\.\d{1,3}\.\d{1,3})))([a-z\d]|(\.(?!(\.|-)))|(-(?!\.))){1,61}[a-z\d]$)
+    Description: "Enter a name for the Amazon S3 bucket where you want to store Amazon\
+      \ ALB access logs. This can be the name of either an existing S3 bucket, or\
+      \ a new bucket that the template will create during stack launch (if it does\
+      \ not find a matching bucket name). The solution will modify the bucket\xE2\u20AC\
+      \u2122s notification configuration to trigger the Log Parser AWS Lambda function\
+      \ whenever a new log file is saved in this bucket. More about bucket name restriction\
+      \ here: http://amzn.to/1p1YlU5"
+  SendAnonymousUsageData:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Send anonymous data to AWS to help us understand solution usage across
+      our customer base as a whole. To opt out of this feature, select No.
+  RequestThreshold:
+    Type: Number
+    Default: '2000'
+    MinValue: '2000'
+    Description: If you chose yes for the Activate HTTP Flood Protection parameter,
+      enter the maximum acceptable requests per FIVE-minute period per IP address.
+      Minimum value of 2000. If you chose to deactivate this protection, ignore this
+      parameter.
+  ErrorThreshold:
+    Type: Number
+    Default: '50'
+    MinValue: '0'
+    Description: If you chose yes for the Activate Scanners & Probes Protection parameter,
+      enter the maximum acceptable bad requests per minute per IP. If you chose to
+      deactivate Scanners & Probes protection, ignore this parameter.
+  WAFBlockPeriod:
+    Type: Number
+    Default: '240'
+    MinValue: '0'
+    Description: If you chose yes for the Activate Scanners & Probes Protection parameters,
+      enter the period (in minutes) to block applicable IP addresses. If you chose
+      to deactivate this protection, ignore this parameter.
+Conditions:
+  AssociateWithALB: !Not
+    - !Equals
+      - !Ref 'ApplicationLoadBalancerArn'
+      - ''
+  SqlInjectionProtectionActivated: !Equals
+    - !Ref 'SqlInjectionProtectionParam'
+    - 'yes'
+  CrossSiteScriptingProtectionActivated: !Equals
+    - !Ref 'CrossSiteScriptingProtectionParam'
+    - 'yes'
+  HttpFloodProtectionActivated: !Equals
+    - !Ref 'ActivateHttpFloodProtectionParam'
+    - 'yes'
+  ScansProbesProtectionActivated: !Equals
+    - !Ref 'ActivateScansProbesProtectionParam'
+    - 'yes'
+  ReputationListsProtectionActivated: !Equals
+    - !Ref 'ActivateReputationListsProtectionParam'
+    - 'yes'
+  BadBotProtectionActivated: !Equals
+    - !Ref 'ActivateBadBotProtectionParam'
+    - 'yes'
+  LogParserActivated: !Equals
+    - !Ref 'ActivateScansProbesProtectionParam'
+    - 'yes'
+  CreateWebACL: !Or
+    - !Condition 'SqlInjectionProtectionActivated'
+    - !Condition 'CrossSiteScriptingProtectionActivated'
+    - !Condition 'HttpFloodProtectionActivated'
+    - !Condition 'ScansProbesProtectionActivated'
+    - !Condition 'ReputationListsProtectionActivated'
+    - !Condition 'BadBotProtectionActivated'
+Resources:
+  WebAclAssociation:
+    Type: AWS::WAFRegional::WebACLAssociation
+    Condition: AssociateWithALB
+    Properties:
+      ResourceArn: !Ref 'ApplicationLoadBalancerArn'
+      WebACLId: !Ref 'WAFWebACL'
+  WAFWhitelistSet:
+    Type: AWS::WAFRegional::IPSet
+    Condition: CreateWebACL
+    Properties:
+      Name: !Sub '${AWS::StackName} - Whitelist Set'
+  WAFBlacklistSet:
+    Type: AWS::WAFRegional::IPSet
+    Condition: LogParserActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - Blacklist Set'
+  WAFScansProbesSet:
+    Type: AWS::WAFRegional::IPSet
+    Condition: LogParserActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - Scans Probes Set'
+  WAFReputationListsSet1:
+    Type: AWS::WAFRegional::IPSet
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Reputation Lists Set #1'
+  WAFReputationListsSet2:
+    Type: AWS::WAFRegional::IPSet
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Reputation Lists Set #2'
+  WAFBadBotSet:
+    Type: AWS::WAFRegional::IPSet
+    Condition: BadBotProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Bad Bot Set'
+  WAFSqlInjectionDetection:
+    Type: AWS::WAFRegional::SqlInjectionMatchSet
+    Condition: SqlInjectionProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - SQL injection Detection'
+      SqlInjectionMatchTuples:
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Authorization
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Authorization
+          TextTransformation: HTML_ENTITY_DECODE
+  WAFXssDetection:
+    Type: AWS::WAFRegional::XssMatchSet
+    Condition: CrossSiteScriptingProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - XSS Detection Detection'
+      XssMatchTuples:
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: HTML_ENTITY_DECODE
+  WAFWhitelistRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: CreateWebACL
+    DependsOn: WAFWhitelistSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Whitelist Rule'
+      MetricName: SecurityAutomationsWhitelistRule
+      Predicates:
+        - DataId: !Ref 'WAFWhitelistSet'
+          Negated: false
+          Type: IPMatch
+  WAFBlacklistRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: LogParserActivated
+    DependsOn: WAFBlacklistSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Blacklist Rule'
+      MetricName: SecurityAutomationsBlacklistRule
+      Predicates:
+        - DataId: !Ref 'WAFBlacklistSet'
+          Negated: false
+          Type: IPMatch
+  WAFScansProbesRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: LogParserActivated
+    DependsOn: WAFScansProbesSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Scans Probes Rule'
+      MetricName: SecurityAutomationsScansProbesRule
+      Predicates:
+        - DataId: !Ref 'WAFScansProbesSet'
+          Negated: false
+          Type: IPMatch
+  WAFIPReputationListsRule1:
+    Type: AWS::WAFRegional::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn: WAFReputationListsSet1
+    Properties:
+      Name: !Sub '${AWS::StackName} - WAF IP Reputation Lists Rule #1'
+      MetricName: SecurityAutomationsIPReputationListsRule1
+      Predicates:
+        - DataId: !Ref 'WAFReputationListsSet1'
+          Type: IPMatch
+          Negated: false
+  WAFIPReputationListsRule2:
+    Type: AWS::WAFRegional::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn: WAFReputationListsSet2
+    Properties:
+      Name: !Sub '${AWS::StackName} - WAF IP Reputation Lists Rule #2'
+      MetricName: SecurityAutomationsIPReputationListsRule2
+      Predicates:
+        - DataId: !Ref 'WAFReputationListsSet2'
+          Type: IPMatch
+          Negated: false
+  WAFBadBotRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: BadBotProtectionActivated
+    DependsOn: WAFBadBotSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Bad Bot Rule'
+      MetricName: SecurityAutomationsBadBotRule
+      Predicates:
+        - DataId: !Ref 'WAFBadBotSet'
+          Type: IPMatch
+          Negated: false
+  WAFSqlInjectionRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: SqlInjectionProtectionActivated
+    DependsOn: WAFSqlInjectionDetection
+    Properties:
+      Name: !Sub '${AWS::StackName} - SQL Injection Rule'
+      MetricName: SecurityAutomationsSqlInjectionRule
+      Predicates:
+        - DataId: !Ref 'WAFSqlInjectionDetection'
+          Negated: false
+          Type: SqlInjectionMatch
+  WAFXssRule:
+    Type: AWS::WAFRegional::Rule
+    Condition: CrossSiteScriptingProtectionActivated
+    DependsOn: WAFXssDetection
+    Properties:
+      Name: !Sub '${AWS::StackName} - XSS Rule'
+      MetricName: SecurityAutomationsXssRule
+      Predicates:
+        - DataId: !Ref 'WAFXssDetection'
+          Negated: false
+          Type: XssMatch
+  WAFWebACL:
+    Type: AWS::WAFRegional::WebACL
+    Condition: CreateWebACL
+    DependsOn:
+      - WAFWhitelistRule
+    Properties:
+      Name: !Ref 'AWS::StackName'
+      DefaultAction:
+        Type: ALLOW
+      MetricName: SecurityAutomationsMaliciousRequesters
+      Rules:
+        - Action:
+            Type: ALLOW
+          Priority: 10
+          RuleId: !Ref 'WAFWhitelistRule'
+  LambdaRoleLogParser:
+    Type: AWS::IAM::Role
+    Condition: LogParserActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}/*'
+        - PolicyName: S3AccessPut
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}/aws-waf-security-automations-current-blocked-ips.json'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf-regional:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetIPSet
+                  - waf-regional:UpdateIPSet
+                Resource:
+                  - !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFBlacklistSet}'
+                  - !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFScansProbesSet}'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFLogParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: LogParserActivated
+    DependsOn:
+      - LambdaRoleLogParser
+      - WAFBlacklistSet
+      - WAFScansProbesSet
+    Properties:
+      Description: !Sub 'This function parses ALB access logs to identify suspicious
+        behavior, such as an abnormal amount of errors. It then blocks those IP addresses
+        for a customer-defined period of time. Parameters: ${ErrorThreshold},${WAFBlockPeriod}.'
+      Handler: log-parser.lambda_handler
+      Role: !GetAtt 'LambdaRoleLogParser.Arn'
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v2/log-parser.zip
+      Environment:
+        Variables:
+          OUTPUT_BUCKET: !Ref 'AccessLogBucket'
+          IP_SET_ID_BLACKLIST: !Ref 'WAFBlacklistSet'
+          IP_SET_ID_AUTO_BLOCK: !Ref 'WAFScansProbesSet'
+          BLACKLIST_BLOCK_PERIOD: !Ref 'WAFBlockPeriod'
+          ERROR_PER_MINUTE_LIMIT: !Ref 'ErrorThreshold'
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+          LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION: '10000'
+          MAX_AGE_TO_UPDATE: '30'
+          REGION: !Ref 'AWS::Region'
+          LOG_TYPE: alb
+      Runtime: python2.7
+      MemorySize: 512
+      Timeout: 300
+  LambdaInvokePermissionLogParser:
+    Type: AWS::Lambda::Permission
+    Condition: LogParserActivated
+    DependsOn: LambdaWAFLogParserFunction
+    Properties:
+      FunctionName: !GetAtt 'LambdaWAFLogParserFunction.Arn'
+      Action: lambda:*
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref 'AWS::AccountId'
+  LambdaRoleReputationListsParser:
+    Type: AWS::IAM::Role
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf-regional:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetIPSet
+                  - waf-regional:UpdateIPSet
+                Resource:
+                  - !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFReputationListsSet1}'
+                  - !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFReputationListsSet2}'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFReputationListsParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: ReputationListsProtectionActivated
+    DependsOn: LambdaRoleReputationListsParser
+    Properties:
+      Description: This lambda function checks third-party IP reputation lists hourly
+        for new IP ranges to block. These lists include the Spamhaus Dont Route Or
+        Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats
+        IP list, and the Tor exit node list.
+      Handler: reputation-lists-parser.handler
+      Role: !GetAtt 'LambdaRoleReputationListsParser.Arn'
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v3/reputation-lists-parser.zip
+      Runtime: nodejs6.10
+      MemorySize: 128
+      Timeout: 300
+      Environment:
+        Variables:
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+  LambdaWAFReputationListsParserEventsRule:
+    Type: AWS::Events::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn:
+      - LambdaWAFReputationListsParserFunction
+      - WAFReputationListsSet1
+      - WAFReputationListsSet2
+    Properties:
+      Description: Security Automations - WAF Reputation Lists
+      ScheduleExpression: rate(1 hour)
+      Targets:
+        - Arn: !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+          Id: LambdaWAFReputationListsParserFunction
+          Input: !Sub '{"lists":[{"url":"https://www.spamhaus.org/drop/drop.txt"},{"url":"https://check.torproject.org/exit-addresses","prefix":"ExitAddress
+            "},{"url":"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt"}],"logType":"alb","region":"${AWS::Region}","ipSetIds":
+            ["${WAFReputationListsSet1}","${WAFReputationListsSet2}"]}'
+  LambdaInvokePermissionReputationListsParser:
+    Type: AWS::Lambda::Permission
+    Condition: ReputationListsProtectionActivated
+    DependsOn:
+      - LambdaWAFReputationListsParserFunction
+      - LambdaWAFReputationListsParserEventsRule
+    Properties:
+      FunctionName: !Ref 'LambdaWAFReputationListsParserFunction'
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt 'LambdaWAFReputationListsParserEventsRule.Arn'
+  LambdaRoleBadBot:
+    Type: AWS::IAM::Role
+    Condition: BadBotProtectionActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf-regional:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetIPSet
+                  - waf-regional:UpdateIPSet
+                Resource: !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/${WAFBadBotSet}'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFBadBotParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: BadBotProtectionActivated
+    DependsOn: LambdaRoleBadBot
+    Properties:
+      Description: This lambda function will intercepts and inspects trap endpoint
+        requests to extract its IP address, and then add it to an AWS WAF block list.
+      Handler: access-handler.lambda_handler
+      Role: !GetAtt 'LambdaRoleBadBot.Arn'
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v2/access-handler.zip
+      Environment:
+        Variables:
+          IP_SET_ID_BAD_BOT: !Ref 'WAFBadBotSet'
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+          REGION: !Ref 'AWS::Region'
+          LOG_TYPE: alb
+      Runtime: python2.7
+      MemorySize: 128
+      Timeout: 300
+  LambdaInvokePermissionBadBot:
+    Type: AWS::Lambda::Permission
+    Condition: BadBotProtectionActivated
+    DependsOn: LambdaWAFBadBotParserFunction
+    Properties:
+      FunctionName: !GetAtt 'LambdaWAFBadBotParserFunction.Arn'
+      Action: lambda:*
+      Principal: apigateway.amazonaws.com
+  ApiGatewayBadBot:
+    Type: AWS::ApiGateway::RestApi
+    Condition: BadBotProtectionActivated
+    Properties:
+      Name: Security Automations - WAF Bad Bot API
+      Description: API created by AWS WAF Security Automations CloudFormation template.
+        This endpoint will be used to capture bad bots.
+  ApiGatewayBadBotResource:
+    Type: AWS::ApiGateway::Resource
+    Condition: BadBotProtectionActivated
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ParentId: !GetAtt 'ApiGatewayBadBot.RootResourceId'
+      PathPart: '{proxy+}'
+  ApiGatewayBadBotMethodRoot:
+    Type: AWS::ApiGateway::Method
+    Condition: BadBotProtectionActivated
+    DependsOn:
+      - LambdaWAFBadBotParserFunction
+      - LambdaInvokePermissionBadBot
+      - ApiGatewayBadBot
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ResourceId: !GetAtt 'ApiGatewayBadBot.RootResourceId'
+      HttpMethod: ANY
+      AuthorizationType: NONE
+      RequestParameters:
+        method.request.header.X-Forwarded-For: false
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations'
+  ApiGatewayBadBotMethod:
+    Type: AWS::ApiGateway::Method
+    Condition: BadBotProtectionActivated
+    DependsOn:
+      - LambdaWAFBadBotParserFunction
+      - LambdaInvokePermissionBadBot
+      - ApiGatewayBadBot
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ResourceId: !Ref 'ApiGatewayBadBotResource'
+      HttpMethod: ANY
+      AuthorizationType: NONE
+      RequestParameters:
+        method.request.header.X-Forwarded-For: false
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations'
+  ApiGatewayBadBotDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Condition: BadBotProtectionActivated
+    DependsOn: ApiGatewayBadBotMethod
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      Description: CloudFormation Deployment Stage
+      StageName: CFDeploymentStage
+  ApiGatewayBadBotStage:
+    Type: AWS::ApiGateway::Stage
+    Condition: BadBotProtectionActivated
+    DependsOn: ApiGatewayBadBotDeployment
+    Properties:
+      DeploymentId: !Ref 'ApiGatewayBadBotDeployment'
+      Description: Production Stage
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      StageName: ProdStage
+  LambdaRoleCustomResource:
+    Type: AWS::IAM::Role
+    Condition: CreateWebACL
+    DependsOn: WAFWebACL
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                  - s3:GetBucketLocation
+                  - s3:GetBucketNotification
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:PutBucketNotification
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}'
+        - !If
+          - ReputationListsProtectionActivated
+          - PolicyName: LambdaAccess
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action: lambda:InvokeFunction
+                  Resource: !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+          - !Ref 'AWS::NoValue'
+        - PolicyName: WAFAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetWebACL
+                  - waf-regional:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:webacl/${WAFWebACL}'
+        - PolicyName: WAFRuleAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetRule
+                  - waf-regional:GetIPSet
+                  - waf-regional:UpdateIPSet
+                  - waf-regional:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:rule/*'
+        - PolicyName: WAFIPSetAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetIPSet
+                  - waf-regional:UpdateIPSet
+                Resource: !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ipset/*'
+        - PolicyName: WAFRateBasedRuleAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf-regional:GetRateBasedRule
+                  - waf-regional:CreateRateBasedRule
+                  - waf-regional:DeleteRateBasedRule
+                  - waf-regional:ListRateBasedRules
+                  - waf-regional:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf-regional:${AWS::Region}:${AWS::AccountId}:ratebasedrule/*'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf-regional:GetChangeToken
+                Resource: '*'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+  LambdaWAFCustomResourceFunction:
+    Type: AWS::Lambda::Function
+    Condition: CreateWebACL
+    DependsOn: LambdaRoleCustomResource
+    Properties:
+      Description: This lambda function configures the Web ACL rules based on the
+        features enabled in the CloudFormation template.
+      Handler: custom-resource.lambda_handler
+      Role: !GetAtt 'LambdaRoleCustomResource.Arn'
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v4/custom-resource.zip
+      Runtime: python2.7
+      MemorySize: 128
+      Timeout: 300
+  WafWebAclRuleControler:
+    Type: Custom::WafWebAclRuleControler
+    Condition: CreateWebACL
+    DependsOn:
+      - LambdaWAFCustomResourceFunction
+      - WAFWebACL
+    Properties:
+      ServiceToken: !GetAtt 'LambdaWAFCustomResourceFunction.Arn'
+      StackName: !Ref 'AWS::StackName'
+      RuleAction: !Ref 'RuleAction'
+      WAFWebACL: !Ref 'WAFWebACL'
+      Region: !Ref 'AWS::Region'
+      LambdaWAFReputationListsParserFunction: !If
+        - ReputationListsProtectionActivated
+        - !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+        - !Ref 'AWS::NoValue'
+      WAFWhitelistSet: !Ref 'WAFWhitelistSet'
+      WAFBlacklistSet: !If
+        - LogParserActivated
+        - !Ref 'WAFBlacklistSet'
+        - !Ref 'AWS::NoValue'
+      WAFScansProbesSet: !If
+        - ScansProbesProtectionActivated
+        - !Ref 'WAFScansProbesSet'
+        - !Ref 'AWS::NoValue'
+      WAFReputationListsSet1: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFReputationListsSet1'
+        - !Ref 'AWS::NoValue'
+      WAFReputationListsSet2: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFReputationListsSet2'
+        - !Ref 'AWS::NoValue'
+      WAFBadBotSet: !If
+        - BadBotProtectionActivated
+        - !Ref 'WAFBadBotSet'
+        - !Ref 'AWS::NoValue'
+      AccessLogBucket: !If
+        - LogParserActivated
+        - !Ref 'AccessLogBucket'
+        - !Ref 'AWS::NoValue'
+      LambdaWAFLogParserFunction: !If
+        - LogParserActivated
+        - !GetAtt 'LambdaWAFLogParserFunction.Arn'
+        - !Ref 'AWS::NoValue'
+      WAFWhitelistRule: !If
+        - CreateWebACL
+        - !Ref 'WAFWhitelistRule'
+        - !Ref 'AWS::NoValue'
+      WAFBlacklistRule: !If
+        - LogParserActivated
+        - !Ref 'WAFBlacklistRule'
+        - !Ref 'AWS::NoValue'
+      WAFScansProbesRule: !If
+        - LogParserActivated
+        - !Ref 'WAFScansProbesRule'
+        - !Ref 'AWS::NoValue'
+      WAFIPReputationListsRule1: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFIPReputationListsRule1'
+        - !Ref 'AWS::NoValue'
+      WAFIPReputationListsRule2: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFIPReputationListsRule2'
+        - !Ref 'AWS::NoValue'
+      WAFBadBotRule: !If
+        - BadBotProtectionActivated
+        - !Ref 'WAFBadBotRule'
+        - !Ref 'AWS::NoValue'
+      WAFSqlInjectionRule: !If
+        - SqlInjectionProtectionActivated
+        - !Ref 'WAFSqlInjectionRule'
+        - !Ref 'AWS::NoValue'
+      WAFXssRule: !If
+        - CrossSiteScriptingProtectionActivated
+        - !Ref 'WAFXssRule'
+        - !Ref 'AWS::NoValue'
+      SqlInjectionProtection: !Ref 'SqlInjectionProtectionParam'
+      CrossSiteScriptingProtection: !Ref 'CrossSiteScriptingProtectionParam'
+      ActivateHttpFloodProtection: !Ref 'ActivateHttpFloodProtectionParam'
+      ActivateScansProbesProtection: !Ref 'ActivateScansProbesProtectionParam'
+      ActivateReputationListsProtection: !Ref 'ActivateReputationListsProtectionParam'
+      ActivateBadBotProtection: !Ref 'ActivateBadBotProtectionParam'
+      RequestThreshold: !Ref 'RequestThreshold'
+      ErrorThreshold: !Ref 'ErrorThreshold'
+      WAFBlockPeriod: !Ref 'WAFBlockPeriod'
+      SendAnonymousUsageData: !Ref 'SendAnonymousUsageData'
+      UUID: !GetAtt 'CreateUniqueID.UUID'
+      LOG_TYPE: alb
+  SolutionHelperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: Solution_Helper_Permissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+  SolutionHelper:
+    Type: AWS::Lambda::Function
+    DependsOn: SolutionHelperRole
+    Properties:
+      Handler: solution-helper.lambda_handler
+      Role: !GetAtt 'SolutionHelperRole.Arn'
+      Description: This lambda function executes generic common tasks to support this
+        solution.
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: library/solution-helper/v1/solution-helper.zip
+      Runtime: python2.7
+      Timeout: 300
+  CreateUniqueID:
+    Type: Custom::CreateUUID
+    DependsOn: SolutionHelper
+    Properties:
+      ServiceToken: !GetAtt 'SolutionHelper.Arn'
+      Region: !Ref 'AWS::Region'
+      CreateUniqueID: 'true'
+Outputs:
+  BadBotHoneypotEndpoint:
+    Description: Bad Bot Honeypot Endpoint
+    Value: !Sub 'https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}'
+    Condition: BadBotProtectionActivated
+  WAFWebACL:
+    Description: AWS WAF WebACL ID
+    Value: !Ref 'WAFWebACL'
+    Condition: CreateWebACL

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -1,1716 +1,1854 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "(SO0006-CloudFront) - AWS WAF Security Automations v2.1: This AWS CloudFormation template helps you provision the AWS WAF Security Automations stack without worrying about creating and configuring the underlying AWS infrastructure. **WARNING** This template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket, and an Amazon CloudWatch custom metric. You will be billed for the AWS resources used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License (the License). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/asl/ or in the license file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.",
-  "Metadata": {
-    "AWS::CloudFormation::Interface": {
-      "ParameterGroups": [{
-        "Label": {
-          "default": "Protection List"
-        },
-        "Parameters": ["SqlInjectionProtectionParam", "CrossSiteScriptingProtectionParam", "ActivateHttpFloodProtectionParam", "ActivateScansProbesProtectionParam", "ActivateReputationListsProtectionParam", "ActivateBadBotProtectionParam"]
-      }, {
-        "Label": {
-          "default": "Settings"
-        },
-        "Parameters": ["AccessLogBucket"]
-      }, {
-        "Label": {
-          "default": "Advanced Settings"
-        },
-        "Parameters": ["RequestThreshold", "ErrorThreshold", "WAFBlockPeriod"]
-      }, {
-        "Label": {
-          "default": "Anonymous Metrics Request"
-        },
-        "Parameters": ["SendAnonymousUsageData"]
-      }],
-      "ParameterLabels": {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "(SO0006-CloudFront) - AWS WAF Security Automations v2.1: This AWS CloudFormation template helps you provision the AWS WAF Security Automations stack without worrying about creating and configuring the underlying AWS infrastructure. **WARNING** This template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket, and an Amazon CloudWatch custom metric. You will be billed for the AWS resources used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software License (the License). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/asl/ or in the license file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.",
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Protection List"
+                    },
+                    "Parameters": [
+                        "SqlInjectionProtectionParam",
+                        "CrossSiteScriptingProtectionParam",
+                        "ActivateHttpFloodProtectionParam",
+                        "ActivateScansProbesProtectionParam",
+                        "ActivateReputationListsProtectionParam",
+                        "ActivateBadBotProtectionParam"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Settings"
+                    },
+                    "Parameters": [
+                        "AccessLogBucket"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Advanced Settings"
+                    },
+                    "Parameters": [
+                        "RequestThreshold",
+                        "ErrorThreshold",
+                        "WAFBlockPeriod"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Anonymous Metrics Request"
+                    },
+                    "Parameters": [
+                        "SendAnonymousUsageData"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "SqlInjectionProtectionParam": {
+                    "default": "Activate SQL Injection Protection"
+                },
+                "CrossSiteScriptingProtectionParam": {
+                    "default": "Activate Cross-site Scripting Protection"
+                },
+                "ActivateHttpFloodProtectionParam": {
+                    "default": "Activate HTTP Flood Protection"
+                },
+                "ActivateScansProbesProtectionParam": {
+                    "default": "Activate Scanner & Probe Protection"
+                },
+                "ActivateReputationListsProtectionParam": {
+                    "default": "Activate Reputation List Protection"
+                },
+                "ActivateBadBotProtectionParam": {
+                    "default": "Activate Bad Bot Protection"
+                },
+                "AccessLogBucket": {
+                    "default": "CloudFront Access Log Bucket Name"
+                },
+                "SendAnonymousUsageData": {
+                    "default": "Send Anonymous Usage Data"
+                },
+                "RequestThreshold": {
+                    "default": "Request Threshold"
+                },
+                "ErrorThreshold": {
+                    "default": "Error Threshold"
+                },
+                "WAFBlockPeriod": {
+                    "default": "WAF Block Period"
+                }
+            }
+        }
+    },
+    "Parameters": {
         "SqlInjectionProtectionParam": {
-          "default": "Activate SQL Injection Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common SQL injection attacks."
         },
         "CrossSiteScriptingProtectionParam": {
-          "default": "Activate Cross-site Scripting Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block common XSS attacks."
         },
         "ActivateHttpFloodProtectionParam": {
-          "default": "Activate HTTP Flood Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block HTTP flood attacks."
         },
         "ActivateScansProbesProtectionParam": {
-          "default": "Activate Scanner & Probe Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block scanners and probes."
         },
         "ActivateReputationListsProtectionParam": {
-          "default": "Activate Reputation List Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats)."
         },
         "ActivateBadBotProtectionParam": {
-          "default": "Activate Bad Bot Protection"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Choose yes to enable the component designed to block bad bots and content scrapers."
         },
         "AccessLogBucket": {
-          "default": "CloudFront Access Log Bucket Name"
+            "Type": "String",
+            "Default": "",
+            "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
+            "Description": "Enter a name for the Amazon S3 bucket where you want to store Amazon CloudFront access logs. This can be the name of either an existing S3 bucket, or a new bucket that the template will create during stack launch (if it does not find a matching bucket name). The solution will modify the bucket\u00e2\u20ac\u2122s notification configuration to trigger the Log Parser AWS Lambda function whenever a new log file is saved in this bucket. More about bucket name restriction here: http://amzn.to/1p1YlU5"
         },
         "SendAnonymousUsageData": {
-          "default": "Send Anonymous Usage Data"
+            "Type": "String",
+            "Default": "yes",
+            "AllowedValues": [
+                "yes",
+                "no"
+            ],
+            "Description": "Send anonymous data to AWS to help us understand solution usage across our customer base as a whole. To opt out of this feature, select No."
         },
         "RequestThreshold": {
-          "default": "Request Threshold"
+            "Type": "Number",
+            "Default": "2000",
+            "MinValue": "2000",
+            "Description": "If you chose yes for the Activate HTTP Flood Protection parameter, enter the maximum acceptable requests per FIVE-minute period per IP address. Minimum value of 2000. If you chose to deactivate this protection, ignore this parameter."
         },
         "ErrorThreshold": {
-          "default": "Error Threshold"
+            "Type": "Number",
+            "Default": "50",
+            "MinValue": "0",
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter the maximum acceptable bad requests per minute per IP. If you chose to deactivate Scanners & Probes protection, ignore this parameter."
         },
         "WAFBlockPeriod": {
-          "default": "WAF Block Period"
+            "Type": "Number",
+            "Default": "240",
+            "MinValue": "0",
+            "Description": "If you chose yes for the Activate Scanners & Probes Protection parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate this protection, ignore this parameter."
         }
-      }
-    }
-  },
-
-
-  "Parameters": {
-    "SqlInjectionProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block common SQL injection attacks."
     },
-    "CrossSiteScriptingProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block common XSS attacks."
-    },
-    "ActivateHttpFloodProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block HTTP flood attacks."
-    },
-    "ActivateScansProbesProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block scanners and probes."
-    },
-    "ActivateReputationListsProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to block requests from IP addresses on third-party reputation lists (supported lists: spamhaus, torproject, and emergingthreats)."
-    },
-    "ActivateBadBotProtectionParam": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Choose yes to enable the component designed to block bad bots and content scrapers."
-    },
-    "AccessLogBucket": {
-      "Type": "String",
-      "Default": "",
-      "AllowedPattern": "(^$|^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$)",
-      "Description": "Enter a name for the Amazon S3 bucket where you want to store Amazon CloudFront access logs. This can be the name of either an existing S3 bucket, or a new bucket that the template will create during stack launch (if it does not find a matching bucket name). The solution will modify the bucket’s notification configuration to trigger the Log Parser AWS Lambda function whenever a new log file is saved in this bucket. More about bucket name restriction here: http://amzn.to/1p1YlU5"
-    },
-    "SendAnonymousUsageData": {
-      "Type": "String",
-      "Default": "yes",
-      "AllowedValues": ["yes", "no"],
-      "Description": "Send anonymous data to AWS to help us understand solution usage across our customer base as a whole. To opt out of this feature, select No."
-    },
-    "RequestThreshold": {
-      "Type": "Number",
-      "Default": "2000",
-      "MinValue": "2000",
-      "Description": "If you chose yes for the Activate HTTP Flood Protection parameter, enter the maximum acceptable requests per FIVE-minute period per IP address. Minimum value of 2000. If you chose to deactivate this protection, ignore this parameter."
-    },
-    "ErrorThreshold": {
-      "Type": "Number",
-      "Default": "50",
-      "MinValue": "0",
-      "Description": "If you chose yes for the Activate Scanners & Probes Protection parameter, enter the maximum acceptable bad requests per minute per IP. If you chose to deactivate Scanners & Probes protection, ignore this parameter."
-    },
-    "WAFBlockPeriod": {
-      "Type": "Number",
-      "Default": "240",
-      "MinValue": "0",
-      "Description": "If you chose yes for the Activate Scanners & Probes Protection parameters, enter the period (in minutes) to block applicable IP addresses. If you chose to deactivate this protection, ignore this parameter."
-    }
-  },
-
-
-  "Conditions": {
-    "SqlInjectionProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "SqlInjectionProtectionParam"
-      }, "yes"]
-    },
-    "CrossSiteScriptingProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "CrossSiteScriptingProtectionParam"
-      }, "yes"]
-    },
-    "HttpFloodProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateHttpFloodProtectionParam"
-      }, "yes"]
-    },
-    "ScansProbesProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateScansProbesProtectionParam"
-      }, "yes"]
-    },
-    "ReputationListsProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateReputationListsProtectionParam"
-      }, "yes"]
-    },
-    "BadBotProtectionActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateBadBotProtectionParam"
-      }, "yes"]
-    },
-    "LogParserActivated": {
-      "Fn::Equals": [{
-        "Ref": "ActivateScansProbesProtectionParam"
-      }, "yes"]
-    },
-    "CreateWebACL": {
-      "Fn::Or": [{
-        "Condition": "SqlInjectionProtectionActivated"
-      }, {
-        "Condition": "CrossSiteScriptingProtectionActivated"
-      }, {
-        "Condition": "HttpFloodProtectionActivated"
-      }, {
-        "Condition": "ScansProbesProtectionActivated"
-      }, {
-        "Condition": "ReputationListsProtectionActivated"
-      }, {
-        "Condition": "BadBotProtectionActivated"
-      }]
-    }
-  },
-  "Resources": {
-    "WAFWhitelistSet": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "CreateWebACL",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Whitelist Set"]]
-        }
-      }
-    },
-    "WAFBlacklistSet": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Blacklist Set"]]
-        }
-      }
-    },
-    "WAFScansProbesSet": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Scans Probes Set"]]
-        }
-      }
-    },
-    "WAFReputationListsSet1": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Reputation Lists Set #1"]]
-        }
-      }
-    },
-    "WAFReputationListsSet2": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Reputation Lists Set #2"]]
-        }
-      }
-    },
-    "WAFBadBotSet": {
-      "Type": "AWS::WAF::IPSet",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "IP Bad Bot Set"]]
-        }
-      }
-    },
-    "WAFSqlInjectionDetection": {
-      "Type": "AWS::WAF::SqlInjectionMatchSet",
-      "Condition": "SqlInjectionProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "SQL injection Detection"]]
-        },
-        "SqlInjectionMatchTuples": [{
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Authorization"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Authorization"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }]
-      }
-    },
-    "WAFXssDetection": {
-      "Type": "AWS::WAF::XssMatchSet",
-      "Condition": "CrossSiteScriptingProtectionActivated",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "XSS Detection Detection"]]
-        },
-        "XssMatchTuples": [{
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "QUERY_STRING"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "BODY"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "URI"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "URL_DECODE"
-        }, {
-          "FieldToMatch": {
-            "Type": "HEADER",
-            "Data": "Cookie"
-          },
-          "TextTransformation": "HTML_ENTITY_DECODE"
-        }]
-      }
-    },
-    "WAFWhitelistRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "CreateWebACL",
-      "DependsOn": "WAFWhitelistSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Whitelist Rule"]]
-        },
-        "MetricName": "SecurityAutomationsWhitelistRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFWhitelistSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFBlacklistRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "LogParserActivated",
-      "DependsOn": "WAFBlacklistSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Blacklist Rule"]]
-        },
-        "MetricName": "SecurityAutomationsBlacklistRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFBlacklistSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFScansProbesRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "LogParserActivated",
-      "DependsOn": "WAFScansProbesSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Scans Probes Rule"]]
-        },
-        "MetricName": "SecurityAutomationsScansProbesRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFScansProbesSet"
-          },
-          "Negated": false,
-          "Type": "IPMatch"
-        }]
-      }
-    },
-    "WAFIPReputationListsRule1": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "WAFReputationListsSet1",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "WAF IP Reputation Lists Rule #1"]]
-        },
-        "MetricName": "SecurityAutomationsIPReputationListsRule1",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFReputationListsSet1"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFIPReputationListsRule2": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "WAFReputationListsSet2",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "WAF IP Reputation Lists Rule #2"]]
-        },
-        "MetricName": "SecurityAutomationsIPReputationListsRule2",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFReputationListsSet2"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFBadBotRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "WAFBadBotSet",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "Bad Bot Rule"]]
-        },
-        "MetricName": "SecurityAutomationsBadBotRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFBadBotSet"
-          },
-          "Type": "IPMatch",
-          "Negated": "false"
-        }]
-      }
-    },
-    "WAFSqlInjectionRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "SqlInjectionProtectionActivated",
-      "DependsOn": "WAFSqlInjectionDetection",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "SQL Injection Rule"]]
-        },
-        "MetricName": "SecurityAutomationsSqlInjectionRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFSqlInjectionDetection"
-          },
-          "Negated": false,
-          "Type": "SqlInjectionMatch"
-        }]
-      }
-    },
-    "WAFXssRule": {
-      "Type": "AWS::WAF::Rule",
-      "Condition": "CrossSiteScriptingProtectionActivated",
-      "DependsOn": "WAFXssDetection",
-      "Properties": {
-        "Name": {
-          "Fn::Join": [" - ", [{
-            "Ref": "AWS::StackName"
-          }, "XSS Rule"]]
-        },
-        "MetricName": "SecurityAutomationsXssRule",
-        "Predicates": [{
-          "DataId": {
-            "Ref": "WAFXssDetection"
-          },
-          "Negated": false,
-          "Type": "XssMatch"
-        }]
-      }
-    },
-    "WAFWebACL": {
-      "Type": "AWS::WAF::WebACL",
-      "Condition": "CreateWebACL",
-      "DependsOn": ["WAFWhitelistRule"],
-      "Properties": {
-        "Name": {
-          "Ref": "AWS::StackName"
-        },
-        "DefaultAction": {
-          "Type": "ALLOW"
-        },
-        "MetricName": "SecurityAutomationsMaliciousRequesters",
-        "Rules": [{
-          "Action": {
-            "Type": "ALLOW"
-          },
-          "Priority": 10,
-          "RuleId": {
-            "Ref": "WAFWhitelistRule"
-          }
-        }]
-      }
-    },
-    "LambdaRoleLogParser": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "LogParserActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "S3Access",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "s3:GetObject",
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }, "/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "S3AccessPut",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "s3:PutObject",
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }, "/aws-waf-security-automations-current-blocked-ips.json"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetIPSet",
-                "waf:UpdateIPSet"
-              ],
-              "Resource": [{
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf::", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFBlacklistSet"
-                    }
-                  ]
-                ]
-              }, {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf::", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFScansProbesSet"
-                    }
-                  ]
-                ]
-              }]
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFLogParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "LogParserActivated",
-      "DependsOn": ["LambdaRoleLogParser", "WAFBlacklistSet", "WAFScansProbesSet"],
-      "Properties": {
-        "Description": {
-          "Fn::Join": ["", [
-            "This function parses CloudFront access logs to identify suspicious behavior, such as an abnormal amount of errors. It then blocks those IP addresses for a customer-defined period of time. Parameters: ", {
-              "Ref": "ErrorThreshold"
-            },
-            ",", {
-              "Ref": "WAFBlockPeriod"
-            },
-            "."
-          ]]
-        },
-        "Handler": "log-parser.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleLogParser", "Arn"]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v2/log-parser.zip"
-        },
-        "Environment": {
-          "Variables": {
-            "OUTPUT_BUCKET": {
-              "Ref": "AccessLogBucket"
-            },
-            "IP_SET_ID_BLACKLIST": {
-              "Ref": "WAFBlacklistSet"
-            },
-            "IP_SET_ID_AUTO_BLOCK": {
-              "Ref": "WAFScansProbesSet"
-            },
-            "BLACKLIST_BLOCK_PERIOD": {
-              "Ref": "WAFBlockPeriod"
-            },
-            "ERROR_PER_MINUTE_LIMIT": {
-              "Ref": "ErrorThreshold"
-            },
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            },
-            "LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION": "10000",
-            "MAX_AGE_TO_UPDATE": "30",
-            "REGION": {
-              "Ref": "AWS::Region"
-            },
-            "LOG_TYPE": "cloudfront"
-          }
-        },
-        "Runtime": "python2.7",
-        "MemorySize": "512",
-        "Timeout": "300"
-      }
-    },
-    "LambdaInvokePermissionLogParser": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "LogParserActivated",
-      "DependsOn": "LambdaWAFLogParserFunction",
-      "Properties": {
-        "FunctionName": {
-          "Fn::GetAtt": ["LambdaWAFLogParserFunction", "Arn"]
-        },
-        "Action": "lambda:*",
-        "Principal": "s3.amazonaws.com",
-        "SourceAccount": {
-          "Ref": "AWS::AccountId"
-        }
-      }
-    },
-    "LambdaRoleReputationListsParser": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "ReputationListsProtectionActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": [
-                "lambda.amazonaws.com"
-              ]
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Policies": [{
-          "PolicyName": "CloudWatchLogs",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetIPSet",
-                "waf:UpdateIPSet"
-              ],
-              "Resource": [{
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf::", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFReputationListsSet1"
-                    }
-                  ]
-                ]
-              }, {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf::", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFReputationListsSet2"
-                    }
-                  ]
-                ]
-              }]
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFReputationListsParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": "LambdaRoleReputationListsParser",
-      "Properties": {
-        "Description": "This lambda function checks third-party IP reputation lists hourly for new IP ranges to block. These lists include the Spamhaus Dont Route Or Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats IP list, and the Tor exit node list.",
-        "Handler": "reputation-lists-parser.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "LambdaRoleReputationListsParser",
-            "Arn"
-          ]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v3/reputation-lists-parser.zip"
-        },
-        "Runtime": "nodejs6.10",
-        "MemorySize": "128",
-        "Timeout": "300",
-        "Environment": {
-          "Variables": {
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            }
-          }
-        }
-      }
-    },
-    "LambdaWAFReputationListsParserEventsRule": {
-      "Type": "AWS::Events::Rule",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": ["LambdaWAFReputationListsParserFunction", "WAFReputationListsSet1", "WAFReputationListsSet2"],
-      "Properties": {
-        "Description": "Security Automations - WAF Reputation Lists",
-        "ScheduleExpression": "rate(1 hour)",
-        "Targets": [{
-          "Arn": {
-            "Fn::GetAtt": [
-              "LambdaWAFReputationListsParserFunction",
-              "Arn"
-            ]
-          },
-          "Id": "LambdaWAFReputationListsParserFunction",
-          "Input": {
-            "Fn::Join": [
-              "", [
-                "{\"lists\":",
-                "[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}]",
-                ",\"logType\":\"cloudfront\"",
-                ",\"region\":\"", {
-                  "Ref": "AWS::Region"
-                }, "\",",
-                "\"ipSetIds\": [",
-                "\"", {
-                  "Ref": "WAFReputationListsSet1"
+    "Conditions": {
+        "SqlInjectionProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "SqlInjectionProtectionParam"
                 },
-                "\",",
-                "\"", {
-                  "Ref": "WAFReputationListsSet2"
-                },
-                "\"",
-                "]}"
-              ]
+                "yes"
             ]
-          }
-        }]
-      }
-    },
-    "LambdaInvokePermissionReputationListsParser": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "ReputationListsProtectionActivated",
-      "DependsOn": ["LambdaWAFReputationListsParserFunction", "LambdaWAFReputationListsParserEventsRule"],
-      "Properties": {
-        "FunctionName": {
-          "Ref": "LambdaWAFReputationListsParserFunction"
         },
-        "Action": "lambda:InvokeFunction",
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "LambdaWAFReputationListsParserEventsRule",
-            "Arn"
-          ]
-        }
-      }
-    },
-    "LambdaRoleBadBot": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
+        "CrossSiteScriptingProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "CrossSiteScriptingProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetAndUpdateIPSet",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetIPSet",
-                "waf:UpdateIPSet"
-              ],
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:waf::", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":ipset/", {
-                      "Ref": "WAFBadBotSet"
-                    }
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudWatchAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudwatch:GetMetricStatistics",
-              "Resource": "*"
-            }]
-          }
-        }]
-      }
-    },
-    "LambdaWAFBadBotParserFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "LambdaRoleBadBot",
-      "Properties": {
-        "Description": "This lambda function will intercepts and inspects trap endpoint requests to extract its IP address, and then add it to an AWS WAF block list.",
-        "Handler": "access-handler.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleBadBot", "Arn"]
+        "HttpFloodProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v2/access-handler.zip"
+        "ScansProbesProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "Environment": {
-          "Variables": {
-            "IP_SET_ID_BAD_BOT": {
-              "Ref": "WAFBadBotSet"
-            },
-            "SEND_ANONYMOUS_USAGE_DATA": {
-              "Ref": "SendAnonymousUsageData"
-            },
-            "UUID": {
-              "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-            },
-            "REGION": {
-              "Ref": "AWS::Region"
-            },
-            "LOG_TYPE": "cloudfront"
-          }
+        "ReputationListsProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "Runtime": "python2.7",
-        "MemorySize": "128",
-        "Timeout": "300"
-      }
-    },
-    "LambdaInvokePermissionBadBot": {
-      "Type": "AWS::Lambda::Permission",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "LambdaWAFBadBotParserFunction",
-      "Properties": {
-        "FunctionName": {
-          "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
+        "BadBotProtectionActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "Action": "lambda:*",
-        "Principal": "apigateway.amazonaws.com"
-      }
-    },
-    "ApiGatewayBadBot": {
-      "Type": "AWS::ApiGateway::RestApi",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "Name": "Security Automations - WAF Bad Bot API",
-        "Description": "API created by AWS WAF Security Automations CloudFormation template. This endpoint will be used to capture bad bots."
-      }
-    },
-    "ApiGatewayBadBotResource": {
-      "Type": "AWS::ApiGateway::Resource",
-      "Condition": "BadBotProtectionActivated",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
+        "LogParserActivated": {
+            "Fn::Equals": [
+                {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "yes"
+            ]
         },
-        "ParentId": {
-          "Fn::GetAtt": ["ApiGatewayBadBot", "RootResourceId"]
-        },
-        "PathPart": "{proxy+}"
-      }
-    },
-    "ApiGatewayBadBotMethodRoot": {
-      "Type": "AWS::ApiGateway::Method",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": ["LambdaWAFBadBotParserFunction", "LambdaInvokePermissionBadBot", "ApiGatewayBadBot"],
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "ResourceId": {
-          "Fn::GetAtt": ["ApiGatewayBadBot", "RootResourceId"]
-        },
-        "HttpMethod": "ANY",
-        "AuthorizationType": "NONE",
-        "RequestParameters": {
-          "method.request.header.X-Forwarded-For": false
-        },
-        "Integration": {
-          "Type": "AWS_PROXY",
-          "IntegrationHttpMethod": "POST",
-          "Uri": {
-            "Fn::Join": ["", [
-              "arn:aws:apigateway:", {
-                "Ref": "AWS::Region"
-              },
-              ":lambda:path/2015-03-31/functions/", {
-                "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
-              },
-              "/invocations"
-            ]]
-          }
-        }
-      }
-    },
-    "ApiGatewayBadBotMethod": {
-      "Type": "AWS::ApiGateway::Method",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": ["LambdaWAFBadBotParserFunction", "LambdaInvokePermissionBadBot", "ApiGatewayBadBot"],
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "ResourceId": {
-          "Ref": "ApiGatewayBadBotResource"
-        },
-        "HttpMethod": "ANY",
-        "AuthorizationType": "NONE",
-        "RequestParameters": {
-          "method.request.header.X-Forwarded-For": false
-        },
-        "Integration": {
-          "Type": "AWS_PROXY",
-          "IntegrationHttpMethod": "POST",
-          "Uri": {
-            "Fn::Join": ["", [
-              "arn:aws:apigateway:", {
-                "Ref": "AWS::Region"
-              },
-              ":lambda:path/2015-03-31/functions/", {
-                "Fn::GetAtt": ["LambdaWAFBadBotParserFunction", "Arn"]
-              },
-              "/invocations"
-            ]]
-          }
-        }
-      }
-    },
-    "ApiGatewayBadBotDeployment": {
-      "Type": "AWS::ApiGateway::Deployment",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "ApiGatewayBadBotMethod",
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "Description": "CloudFormation Deployment Stage",
-        "StageName": "CFDeploymentStage"
-      }
-    },
-    "ApiGatewayBadBotStage": {
-      "Type": "AWS::ApiGateway::Stage",
-      "Condition": "BadBotProtectionActivated",
-      "DependsOn": "ApiGatewayBadBotDeployment",
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ApiGatewayBadBotDeployment"
-        },
-        "Description": "Production Stage",
-        "RestApiId": {
-          "Ref": "ApiGatewayBadBot"
-        },
-        "StageName": "ProdStage"
-      }
-    },
-    "LambdaRoleCustomResource": {
-      "Type": "AWS::IAM::Role",
-      "Condition": "CreateWebACL",
-      "DependsOn": "WAFWebACL",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": ["lambda.amazonaws.com"]
-            },
-            "Action": ["sts:AssumeRole"]
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "S3Access",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "s3:CreateBucket",
-                "s3:GetBucketLocation",
-                "s3:GetBucketNotification",
-                "s3:GetObject",
-                "s3:ListBucket",
-                "s3:PutBucketNotification"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:s3:::", {
-                  "Ref": "AccessLogBucket"
-                }]]
-              }
-            }]
-          }
-        }, {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "PolicyName": "LambdaAccess",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [{
-                "Effect": "Allow",
-                "Action": "lambda:InvokeFunction",
-                "Resource": {
-                  "Fn::GetAtt": ["LambdaWAFReputationListsParserFunction", "Arn"]
+        "CreateWebACL": {
+            "Fn::Or": [
+                {
+                    "Condition": "SqlInjectionProtectionActivated"
+                },
+                {
+                    "Condition": "CrossSiteScriptingProtectionActivated"
+                },
+                {
+                    "Condition": "HttpFloodProtectionActivated"
+                },
+                {
+                    "Condition": "ScansProbesProtectionActivated"
+                },
+                {
+                    "Condition": "ReputationListsProtectionActivated"
+                },
+                {
+                    "Condition": "BadBotProtectionActivated"
                 }
-              }]
-            }
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
-        }, {
-          "PolicyName": "WAFAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetWebACL",
-                "waf:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf::", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":webacl/", {
-                    "Ref": "WAFWebACL"
-                  }
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFRuleAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetRule",
-                "waf:GetIPSet",
-                "waf:UpdateIPSet",
-                "waf:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf::", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":rule/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFIPSetAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetIPSet",
-                "waf:UpdateIPSet"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf::", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":ipset/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFRateBasedRuleAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": [
-                "waf:GetRateBasedRule",
-                "waf:CreateRateBasedRule",
-                "waf:DeleteRateBasedRule",
-                "waf:ListRateBasedRules",
-                "waf:UpdateWebACL"
-              ],
-              "Resource": {
-                "Fn::Join": ["", ["arn:aws:waf::", {
-                    "Ref": "AWS::AccountId"
-                  },
-                  ":ratebasedrule/*"
-                ]]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "CloudFormationAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "cloudformation:DescribeStacks",
-              "Resource": {
-                "Fn::Join": [
-                  "", [
-                    "arn:aws:cloudformation:", {
-                      "Ref": "AWS::Region"
-                    },
-                    ":", {
-                      "Ref": "AWS::AccountId"
-                    },
-                    ":stack/", {
-                      "Ref": "AWS::StackName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            }]
-          }
-        }, {
-          "PolicyName": "WAFGetChangeToken",
-          "PolicyDocument": {
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": "waf:GetChangeToken",
-              "Resource": "*"
-            }]
-          }
-        }, {
-          "PolicyName": "LogsAccess",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }]
-      }
+            ]
+        }
     },
-    "LambdaWAFCustomResourceFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Condition": "CreateWebACL",
-      "DependsOn": "LambdaRoleCustomResource",
-      "Properties": {
-        "Description": "This lambda function configures the Web ACL rules based on the features enabled in the CloudFormation template.",
-        "Handler": "custom-resource.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": ["LambdaRoleCustomResource", "Arn"]
-        },
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": ["-", [
-              "%%BUCKET_NAME%%", {
-                "Ref": "AWS::Region"
-              }
-            ]]
-          },
-          "S3Key": "aws-waf-security-automations/v4/custom-resource.zip"
-        },
-        "Runtime": "python2.7",
-        "MemorySize": "128",
-        "Timeout": "300"
-      }
-    },
-    "WafWebAclRuleControler": {
-      "Type": "Custom::WafWebAclRuleControler",
-      "Condition": "CreateWebACL",
-      "DependsOn": ["LambdaWAFCustomResourceFunction", "WAFWebACL"],
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": ["LambdaWAFCustomResourceFunction", "Arn"]
-        },
-        "StackName": {
-          "Ref": "AWS::StackName"
-        },
-        "WAFWebACL": {
-          "Ref": "WAFWebACL"
-        },
-        "Region": {
-          "Ref": "AWS::Region"
-        },
-        "LambdaWAFReputationListsParserFunction": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Fn::GetAtt": ["LambdaWAFReputationListsParserFunction", "Arn"]
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
-        },
+    "Resources": {
         "WAFWhitelistSet": {
-          "Ref": "WAFWhitelistSet"
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "CreateWebACL",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Whitelist Set"
+                }
+            }
         },
         "WAFBlacklistSet": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFBlacklistSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Blacklist Set"
+                }
+            }
         },
         "WAFScansProbesSet": {
-          "Fn::If": ["ScansProbesProtectionActivated", {
-            "Ref": "WAFScansProbesSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Scans Probes Set"
+                }
+            }
         },
         "WAFReputationListsSet1": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFReputationListsSet1"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Reputation Lists Set #1"
+                }
+            }
         },
         "WAFReputationListsSet2": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFReputationListsSet2"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Reputation Lists Set #2"
+                }
+            }
         },
         "WAFBadBotSet": {
-          "Fn::If": ["BadBotProtectionActivated", {
-            "Ref": "WAFBadBotSet"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::IPSet",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - IP Bad Bot Set"
+                }
+            }
         },
-        "AccessLogBucket": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "AccessLogBucket"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+        "WAFSqlInjectionDetection": {
+            "Type": "AWS::WAF::SqlInjectionMatchSet",
+            "Condition": "SqlInjectionProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - SQL injection Detection"
+                },
+                "SqlInjectionMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Authorization"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Authorization"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    }
+                ]
+            }
         },
-        "LambdaWAFLogParserFunction": {
-          "Fn::If": ["LogParserActivated", {
-            "Fn::GetAtt": ["LambdaWAFLogParserFunction", "Arn"]
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+        "WAFXssDetection": {
+            "Type": "AWS::WAF::XssMatchSet",
+            "Condition": "CrossSiteScriptingProtectionActivated",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - XSS Detection Detection"
+                },
+                "XssMatchTuples": [
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "QUERY_STRING"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "BODY"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "URI"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "URL_DECODE"
+                    },
+                    {
+                        "FieldToMatch": {
+                            "Type": "HEADER",
+                            "Data": "Cookie"
+                        },
+                        "TextTransformation": "HTML_ENTITY_DECODE"
+                    }
+                ]
+            }
         },
         "WAFWhitelistRule": {
-          "Fn::If": ["CreateWebACL", {
-            "Ref": "WAFWhitelistRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "CreateWebACL",
+            "DependsOn": "WAFWhitelistSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Whitelist Rule"
+                },
+                "MetricName": "SecurityAutomationsWhitelistRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFWhitelistSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFBlacklistRule": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFBlacklistRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "LogParserActivated",
+            "DependsOn": "WAFBlacklistSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Blacklist Rule"
+                },
+                "MetricName": "SecurityAutomationsBlacklistRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFScansProbesRule": {
-          "Fn::If": ["LogParserActivated", {
-            "Ref": "WAFScansProbesRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "LogParserActivated",
+            "DependsOn": "WAFScansProbesSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Scans Probes Rule"
+                },
+                "MetricName": "SecurityAutomationsScansProbesRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        "Negated": false,
+                        "Type": "IPMatch"
+                    }
+                ]
+            }
         },
         "WAFIPReputationListsRule1": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFIPReputationListsRule1"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "WAFReputationListsSet1",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - WAF IP Reputation Lists Rule #1"
+                },
+                "MetricName": "SecurityAutomationsIPReputationListsRule1",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFReputationListsSet1"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "false"
+                    }
+                ]
+            }
         },
         "WAFIPReputationListsRule2": {
-          "Fn::If": ["ReputationListsProtectionActivated", {
-            "Ref": "WAFIPReputationListsRule2"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "WAFReputationListsSet2",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - WAF IP Reputation Lists Rule #2"
+                },
+                "MetricName": "SecurityAutomationsIPReputationListsRule2",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFReputationListsSet2"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "false"
+                    }
+                ]
+            }
         },
         "WAFBadBotRule": {
-          "Fn::If": ["BadBotProtectionActivated", {
-            "Ref": "WAFBadBotRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "WAFBadBotSet",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - Bad Bot Rule"
+                },
+                "MetricName": "SecurityAutomationsBadBotRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        "Type": "IPMatch",
+                        "Negated": "false"
+                    }
+                ]
+            }
         },
         "WAFSqlInjectionRule": {
-          "Fn::If": ["SqlInjectionProtectionActivated", {
-            "Ref": "WAFSqlInjectionRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "SqlInjectionProtectionActivated",
+            "DependsOn": "WAFSqlInjectionDetection",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - SQL Injection Rule"
+                },
+                "MetricName": "SecurityAutomationsSqlInjectionRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFSqlInjectionDetection"
+                        },
+                        "Negated": false,
+                        "Type": "SqlInjectionMatch"
+                    }
+                ]
+            }
         },
         "WAFXssRule": {
-          "Fn::If": ["CrossSiteScriptingProtectionActivated", {
-            "Ref": "WAFXssRule"
-          }, {
-            "Ref": "AWS::NoValue"
-          }]
+            "Type": "AWS::WAF::Rule",
+            "Condition": "CrossSiteScriptingProtectionActivated",
+            "DependsOn": "WAFXssDetection",
+            "Properties": {
+                "Name": {
+                    "Fn::Sub": "${AWS::StackName} - XSS Rule"
+                },
+                "MetricName": "SecurityAutomationsXssRule",
+                "Predicates": [
+                    {
+                        "DataId": {
+                            "Ref": "WAFXssDetection"
+                        },
+                        "Negated": false,
+                        "Type": "XssMatch"
+                    }
+                ]
+            }
         },
-        "SqlInjectionProtection": {
-          "Ref": "SqlInjectionProtectionParam"
+        "WAFWebACL": {
+            "Type": "AWS::WAF::WebACL",
+            "Condition": "CreateWebACL",
+            "DependsOn": [
+                "WAFWhitelistRule"
+            ],
+            "Properties": {
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "DefaultAction": {
+                    "Type": "ALLOW"
+                },
+                "MetricName": "SecurityAutomationsMaliciousRequesters",
+                "Rules": [
+                    {
+                        "Action": {
+                            "Type": "ALLOW"
+                        },
+                        "Priority": 10,
+                        "RuleId": {
+                            "Ref": "WAFWhitelistRule"
+                        }
+                    }
+                ]
+            }
         },
-        "CrossSiteScriptingProtection": {
-          "Ref": "CrossSiteScriptingProtectionParam"
+        "LambdaRoleLogParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "LogParserActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:GetObject",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "S3AccessPut",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:PutObject",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}/aws-waf-security-automations-current-blocked-ips.json"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetIPSet",
+                                        "waf:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/${WAFBlacklistSet}"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/${WAFScansProbesSet}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         },
-        "ActivateHttpFloodProtection": {
-          "Ref": "ActivateHttpFloodProtectionParam"
+        "LambdaWAFLogParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "LogParserActivated",
+            "DependsOn": [
+                "LambdaRoleLogParser",
+                "WAFBlacklistSet",
+                "WAFScansProbesSet"
+            ],
+            "Properties": {
+                "Description": {
+                    "Fn::Sub": "This function parses CloudFront access logs to identify suspicious behavior, such as an abnormal amount of errors. It then blocks those IP addresses for a customer-defined period of time. Parameters: ${ErrorThreshold},${WAFBlockPeriod}."
+                },
+                "Handler": "log-parser.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleLogParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "%%BUCKET_NAME%%-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v2/log-parser.zip"
+                },
+                "Environment": {
+                    "Variables": {
+                        "OUTPUT_BUCKET": {
+                            "Ref": "AccessLogBucket"
+                        },
+                        "IP_SET_ID_BLACKLIST": {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        "IP_SET_ID_AUTO_BLOCK": {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        "BLACKLIST_BLOCK_PERIOD": {
+                            "Ref": "WAFBlockPeriod"
+                        },
+                        "ERROR_PER_MINUTE_LIMIT": {
+                            "Ref": "ErrorThreshold"
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION": "10000",
+                        "MAX_AGE_TO_UPDATE": "30",
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "LOG_TYPE": "cloudfront"
+                    }
+                },
+                "Runtime": "python2.7",
+                "MemorySize": "512",
+                "Timeout": "300"
+            }
         },
-        "ActivateScansProbesProtection": {
-          "Ref": "ActivateScansProbesProtectionParam"
-        },
-        "ActivateReputationListsProtection": {
-          "Ref": "ActivateReputationListsProtectionParam"
-        },
-        "ActivateBadBotProtection": {
-          "Ref": "ActivateBadBotProtectionParam"
-        },
-        "RequestThreshold": {
-          "Ref": "RequestThreshold"
-        },
-        "ErrorThreshold": {
-          "Ref": "ErrorThreshold"
-        },
-        "WAFBlockPeriod": {
-          "Ref": "WAFBlockPeriod"
-        },
-        "SendAnonymousUsageData": {
-          "Ref": "SendAnonymousUsageData"
-        },
-        "UUID": {
-          "Fn::GetAtt": ["CreateUniqueID", "UUID"]
-        },
-        "LOG_TYPE": "cloudfront"
-      }
-    },
-    "SolutionHelperRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-              "Service": "lambda.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-          }]
-        },
-        "Path": "/",
-        "Policies": [{
-          "PolicyName": "Solution_Helper_Permissions",
-          "PolicyDocument": {
-            "Version": "2012-10-17",
-            "Statement": [{
-              "Effect": "Allow",
-              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-              "Resource": {
-                "Fn::Join": [":", ["arn:aws:logs", {
-                  "Ref": "AWS::Region"
-                }, {
-                  "Ref": "AWS::AccountId"
-                }, "log-group:/aws/lambda/*"]]
-              }
-            }]
-          }
-        }]
-      }
-    },
-    "SolutionHelper": {
-      "Type": "AWS::Lambda::Function",
-      "DependsOn": "SolutionHelperRole",
-      "Properties": {
-        "Handler": "solution-helper.lambda_handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "SolutionHelperRole",
-            "Arn"
-          ]
-        },
-        "Description": "This lambda function executes generic common tasks to support this solution.",
-        "Code": {
-          "S3Bucket": {
-            "Fn::Join": [
-              "", [
-                "solutions-", {
-                  "Ref": "AWS::Region"
+        "LambdaInvokePermissionLogParser": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "LogParserActivated",
+            "DependsOn": "LambdaWAFLogParserFunction",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFLogParserFunction",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:*",
+                "Principal": "s3.amazonaws.com",
+                "SourceAccount": {
+                    "Ref": "AWS::AccountId"
                 }
-              ]
-            ]
-          },
-          "S3Key": "library/solution-helper/v1/solution-helper.zip"
+            }
         },
-        "Runtime": "python2.7",
-        "Timeout": "300"
-      }
+        "LambdaRoleReputationListsParser": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "ReputationListsProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "CloudWatchLogs",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetIPSet",
+                                        "waf:UpdateIPSet"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/${WAFReputationListsSet1}"
+                                        },
+                                        {
+                                            "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/${WAFReputationListsSet2}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFReputationListsParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": "LambdaRoleReputationListsParser",
+            "Properties": {
+                "Description": "This lambda function checks third-party IP reputation lists hourly for new IP ranges to block. These lists include the Spamhaus Dont Route Or Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats IP list, and the Tor exit node list.",
+                "Handler": "reputation-lists-parser.handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleReputationListsParser",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "%%BUCKET_NAME%%-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v3/reputation-lists-parser.zip"
+                },
+                "Runtime": "nodejs6.10",
+                "MemorySize": "128",
+                "Timeout": "300",
+                "Environment": {
+                    "Variables": {
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "LambdaWAFReputationListsParserEventsRule": {
+            "Type": "AWS::Events::Rule",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFReputationListsParserFunction",
+                "WAFReputationListsSet1",
+                "WAFReputationListsSet2"
+            ],
+            "Properties": {
+                "Description": "Security Automations - WAF Reputation Lists",
+                "ScheduleExpression": "rate(1 hour)",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "LambdaWAFReputationListsParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "LambdaWAFReputationListsParserFunction",
+                        "Input": {
+                            "Fn::Sub": "{\"lists\":[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}],\"logType\":\"cloudfront\",\"region\":\"${AWS::Region}\",\"ipSetIds\": [\"${WAFReputationListsSet1}\",\"${WAFReputationListsSet2}\"]}"
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaInvokePermissionReputationListsParser": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "ReputationListsProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFReputationListsParserFunction",
+                "LambdaWAFReputationListsParserEventsRule"
+            ],
+            "Properties": {
+                "FunctionName": {
+                    "Ref": "LambdaWAFReputationListsParserFunction"
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFReputationListsParserEventsRule",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "LambdaRoleBadBot": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetAndUpdateIPSet",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetIPSet",
+                                        "waf:UpdateIPSet"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/${WAFBadBotSet}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudWatchAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudwatch:GetMetricStatistics",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFBadBotParserFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaRoleBadBot",
+            "Properties": {
+                "Description": "This lambda function will intercepts and inspects trap endpoint requests to extract its IP address, and then add it to an AWS WAF block list.",
+                "Handler": "access-handler.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleBadBot",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "%%BUCKET_NAME%%-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v2/access-handler.zip"
+                },
+                "Environment": {
+                    "Variables": {
+                        "IP_SET_ID_BAD_BOT": {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        "SEND_ANONYMOUS_USAGE_DATA": {
+                            "Ref": "SendAnonymousUsageData"
+                        },
+                        "UUID": {
+                            "Fn::GetAtt": [
+                                "CreateUniqueID",
+                                "UUID"
+                            ]
+                        },
+                        "REGION": {
+                            "Ref": "AWS::Region"
+                        },
+                        "LOG_TYPE": "cloudfront"
+                    }
+                },
+                "Runtime": "python2.7",
+                "MemorySize": "128",
+                "Timeout": "300"
+            }
+        },
+        "LambdaInvokePermissionBadBot": {
+            "Type": "AWS::Lambda::Permission",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "LambdaWAFBadBotParserFunction",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFBadBotParserFunction",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:*",
+                "Principal": "apigateway.amazonaws.com"
+            }
+        },
+        "ApiGatewayBadBot": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "Name": "Security Automations - WAF Bad Bot API",
+                "Description": "API created by AWS WAF Security Automations CloudFormation template. This endpoint will be used to capture bad bots."
+            }
+        },
+        "ApiGatewayBadBotResource": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Condition": "BadBotProtectionActivated",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ParentId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "PathPart": "{proxy+}"
+            }
+        },
+        "ApiGatewayBadBotMethodRoot": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFBadBotParserFunction",
+                "LambdaInvokePermissionBadBot",
+                "ApiGatewayBadBot"
+            ],
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Fn::GetAtt": [
+                        "ApiGatewayBadBot",
+                        "RootResourceId"
+                    ]
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations"
+                    }
+                }
+            }
+        },
+        "ApiGatewayBadBotMethod": {
+            "Type": "AWS::ApiGateway::Method",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": [
+                "LambdaWAFBadBotParserFunction",
+                "LambdaInvokePermissionBadBot",
+                "ApiGatewayBadBot"
+            ],
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "ResourceId": {
+                    "Ref": "ApiGatewayBadBotResource"
+                },
+                "HttpMethod": "ANY",
+                "AuthorizationType": "NONE",
+                "RequestParameters": {
+                    "method.request.header.X-Forwarded-For": false
+                },
+                "Integration": {
+                    "Type": "AWS_PROXY",
+                    "IntegrationHttpMethod": "POST",
+                    "Uri": {
+                        "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations"
+                    }
+                }
+            }
+        },
+        "ApiGatewayBadBotDeployment": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "ApiGatewayBadBotMethod",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "Description": "CloudFormation Deployment Stage",
+                "StageName": "CFDeploymentStage"
+            }
+        },
+        "ApiGatewayBadBotStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Condition": "BadBotProtectionActivated",
+            "DependsOn": "ApiGatewayBadBotDeployment",
+            "Properties": {
+                "DeploymentId": {
+                    "Ref": "ApiGatewayBadBotDeployment"
+                },
+                "Description": "Production Stage",
+                "RestApiId": {
+                    "Ref": "ApiGatewayBadBot"
+                },
+                "StageName": "ProdStage"
+            }
+        },
+        "LambdaRoleCustomResource": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "CreateWebACL",
+            "DependsOn": "WAFWebACL",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "S3Access",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:CreateBucket",
+                                        "s3:GetBucketLocation",
+                                        "s3:GetBucketNotification",
+                                        "s3:GetObject",
+                                        "s3:ListBucket",
+                                        "s3:PutBucketNotification"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:s3:::${AccessLogBucket}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "ReputationListsProtectionActivated",
+                            {
+                                "PolicyName": "LambdaAccess",
+                                "PolicyDocument": {
+                                    "Version": "2012-10-17",
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "lambda:InvokeFunction",
+                                            "Resource": {
+                                                "Fn::GetAtt": [
+                                                    "LambdaWAFReputationListsParserFunction",
+                                                    "Arn"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    },
+                    {
+                        "PolicyName": "WAFAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetWebACL",
+                                        "waf:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:webacl/${WAFWebACL}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFRuleAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetRule",
+                                        "waf:GetIPSet",
+                                        "waf:UpdateIPSet",
+                                        "waf:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:rule/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFIPSetAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetIPSet",
+                                        "waf:UpdateIPSet"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ipset/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFRateBasedRuleAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "waf:GetRateBasedRule",
+                                        "waf:CreateRateBasedRule",
+                                        "waf:DeleteRateBasedRule",
+                                        "waf:ListRateBasedRules",
+                                        "waf:UpdateWebACL"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:waf::${AWS::AccountId}:ratebasedrule/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "CloudFormationAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "cloudformation:DescribeStacks",
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "WAFGetChangeToken",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "waf:GetChangeToken",
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PolicyName": "LogsAccess",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "LambdaWAFCustomResourceFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Condition": "CreateWebACL",
+            "DependsOn": "LambdaRoleCustomResource",
+            "Properties": {
+                "Description": "This lambda function configures the Web ACL rules based on the features enabled in the CloudFormation template.",
+                "Handler": "custom-resource.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaRoleCustomResource",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "%%BUCKET_NAME%%-${AWS::Region}"
+                    },
+                    "S3Key": "aws-waf-security-automations/v4/custom-resource.zip"
+                },
+                "Runtime": "python2.7",
+                "MemorySize": "128",
+                "Timeout": "300"
+            }
+        },
+        "WafWebAclRuleControler": {
+            "Type": "Custom::WafWebAclRuleControler",
+            "Condition": "CreateWebACL",
+            "DependsOn": [
+                "LambdaWAFCustomResourceFunction",
+                "WAFWebACL"
+            ],
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "LambdaWAFCustomResourceFunction",
+                        "Arn"
+                    ]
+                },
+                "StackName": {
+                    "Ref": "AWS::StackName"
+                },
+                "WAFWebACL": {
+                    "Ref": "WAFWebACL"
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "LambdaWAFReputationListsParserFunction": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "LambdaWAFReputationListsParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistSet": {
+                    "Ref": "WAFWhitelistSet"
+                },
+                "WAFBlacklistSet": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFBlacklistSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScansProbesSet": {
+                    "Fn::If": [
+                        "ScansProbesProtectionActivated",
+                        {
+                            "Ref": "WAFScansProbesSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSet1": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFReputationListsSet1"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFReputationListsSet2": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFReputationListsSet2"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotSet": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Ref": "WAFBadBotSet"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "AccessLogBucket": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "AccessLogBucket"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "LambdaWAFLogParserFunction": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Fn::GetAtt": [
+                                "LambdaWAFLogParserFunction",
+                                "Arn"
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFWhitelistRule": {
+                    "Fn::If": [
+                        "CreateWebACL",
+                        {
+                            "Ref": "WAFWhitelistRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBlacklistRule": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFBlacklistRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFScansProbesRule": {
+                    "Fn::If": [
+                        "LogParserActivated",
+                        {
+                            "Ref": "WAFScansProbesRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFIPReputationListsRule1": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFIPReputationListsRule1"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFIPReputationListsRule2": {
+                    "Fn::If": [
+                        "ReputationListsProtectionActivated",
+                        {
+                            "Ref": "WAFIPReputationListsRule2"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFBadBotRule": {
+                    "Fn::If": [
+                        "BadBotProtectionActivated",
+                        {
+                            "Ref": "WAFBadBotRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFSqlInjectionRule": {
+                    "Fn::If": [
+                        "SqlInjectionProtectionActivated",
+                        {
+                            "Ref": "WAFSqlInjectionRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "WAFXssRule": {
+                    "Fn::If": [
+                        "CrossSiteScriptingProtectionActivated",
+                        {
+                            "Ref": "WAFXssRule"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "SqlInjectionProtection": {
+                    "Ref": "SqlInjectionProtectionParam"
+                },
+                "CrossSiteScriptingProtection": {
+                    "Ref": "CrossSiteScriptingProtectionParam"
+                },
+                "ActivateHttpFloodProtection": {
+                    "Ref": "ActivateHttpFloodProtectionParam"
+                },
+                "ActivateScansProbesProtection": {
+                    "Ref": "ActivateScansProbesProtectionParam"
+                },
+                "ActivateReputationListsProtection": {
+                    "Ref": "ActivateReputationListsProtectionParam"
+                },
+                "ActivateBadBotProtection": {
+                    "Ref": "ActivateBadBotProtectionParam"
+                },
+                "RequestThreshold": {
+                    "Ref": "RequestThreshold"
+                },
+                "ErrorThreshold": {
+                    "Ref": "ErrorThreshold"
+                },
+                "WAFBlockPeriod": {
+                    "Ref": "WAFBlockPeriod"
+                },
+                "SendAnonymousUsageData": {
+                    "Ref": "SendAnonymousUsageData"
+                },
+                "UUID": {
+                    "Fn::GetAtt": [
+                        "CreateUniqueID",
+                        "UUID"
+                    ]
+                },
+                "LOG_TYPE": "cloudfront"
+            }
+        },
+        "SolutionHelperRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "Solution_Helper_Permissions",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "SolutionHelper": {
+            "Type": "AWS::Lambda::Function",
+            "DependsOn": "SolutionHelperRole",
+            "Properties": {
+                "Handler": "solution-helper.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "SolutionHelperRole",
+                        "Arn"
+                    ]
+                },
+                "Description": "This lambda function executes generic common tasks to support this solution.",
+                "Code": {
+                    "S3Bucket": {
+                        "Fn::Sub": "solutions-${AWS::Region}"
+                    },
+                    "S3Key": "library/solution-helper/v1/solution-helper.zip"
+                },
+                "Runtime": "python2.7",
+                "Timeout": "300"
+            }
+        },
+        "CreateUniqueID": {
+            "Type": "Custom::CreateUUID",
+            "DependsOn": "SolutionHelper",
+            "Properties": {
+                "ServiceToken": {
+                    "Fn::GetAtt": [
+                        "SolutionHelper",
+                        "Arn"
+                    ]
+                },
+                "Region": {
+                    "Ref": "AWS::Region"
+                },
+                "CreateUniqueID": "true"
+            }
+        }
     },
-    "CreateUniqueID": {
-      "Type": "Custom::CreateUUID",
-      "DependsOn": "SolutionHelper",
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "SolutionHelper",
-            "Arn"
-          ]
+    "Outputs": {
+        "BadBotHoneypotEndpoint": {
+            "Description": "Bad Bot Honeypot Endpoint",
+            "Value": {
+                "Fn::Sub": "https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}"
+            },
+            "Condition": "BadBotProtectionActivated"
         },
-        "Region": {
-          "Ref": "AWS::Region"
-        },
-        "CreateUniqueID": "true"
-      }
+        "WAFWebACL": {
+            "Description": "AWS WAF WebACL ID",
+            "Value": {
+                "Ref": "WAFWebACL"
+            },
+            "Condition": "CreateWebACL"
+        }
     }
-  },
-  "Outputs": {
-    "BadBotHoneypotEndpoint": {
-      "Description": "Bad Bot Honeypot Endpoint",
-      "Value": {
-        "Fn::Join": ["", [
-          "https://", {
-            "Ref": "ApiGatewayBadBot"
-          },
-          ".execute-api.", {
-            "Ref": "AWS::Region"
-          },
-          ".amazonaws.com/", {
-            "Ref": "ApiGatewayBadBotStage"
-          }
-        ]]
-      },
-      "Condition": "BadBotProtectionActivated"
-    },
-    "WAFWebACL": {
-      "Description": "AWS WAF WebACL ID",
-      "Value": {
-        "Ref": "WAFWebACL"
-      },
-      "Condition": "CreateWebACL"
-    }
-  }
 }

--- a/deployment/aws-waf-security-automations.yaml
+++ b/deployment/aws-waf-security-automations.yaml
@@ -1,0 +1,994 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: '(SO0006-CloudFront) - AWS WAF Security Automations v2.1: This AWS CloudFormation
+  template helps you provision the AWS WAF Security Automations stack without worrying
+  about creating and configuring the underlying AWS infrastructure. **WARNING** This
+  template creates an AWS Lambda function, an AWS WAF Web ACL, an Amazon S3 bucket,
+  and an Amazon CloudWatch custom metric. You will be billed for the AWS resources
+  used if you create a stack from this template. **NOTICE** Copyright 2016 Amazon.com,
+  Inc. or its affiliates. All Rights Reserved. Licensed under the Amazon Software
+  License (the License). You may not use this file except in compliance with the License.
+  A copy of the License is located at http://aws.amazon.com/asl/ or in the license
+  file accompanying this file. This file is distributed on an AS IS BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the
+  specific language governing permissions and limitations under the License.'
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Protection List
+        Parameters:
+          - SqlInjectionProtectionParam
+          - CrossSiteScriptingProtectionParam
+          - ActivateHttpFloodProtectionParam
+          - ActivateScansProbesProtectionParam
+          - ActivateReputationListsProtectionParam
+          - ActivateBadBotProtectionParam
+      - Label:
+          default: Settings
+        Parameters:
+          - AccessLogBucket
+      - Label:
+          default: Advanced Settings
+        Parameters:
+          - RequestThreshold
+          - ErrorThreshold
+          - WAFBlockPeriod
+      - Label:
+          default: Anonymous Metrics Request
+        Parameters:
+          - SendAnonymousUsageData
+    ParameterLabels:
+      SqlInjectionProtectionParam:
+        default: Activate SQL Injection Protection
+      CrossSiteScriptingProtectionParam:
+        default: Activate Cross-site Scripting Protection
+      ActivateHttpFloodProtectionParam:
+        default: Activate HTTP Flood Protection
+      ActivateScansProbesProtectionParam:
+        default: Activate Scanner & Probe Protection
+      ActivateReputationListsProtectionParam:
+        default: Activate Reputation List Protection
+      ActivateBadBotProtectionParam:
+        default: Activate Bad Bot Protection
+      AccessLogBucket:
+        default: CloudFront Access Log Bucket Name
+      SendAnonymousUsageData:
+        default: Send Anonymous Usage Data
+      RequestThreshold:
+        default: Request Threshold
+      ErrorThreshold:
+        default: Error Threshold
+      WAFBlockPeriod:
+        default: WAF Block Period
+Parameters:
+  SqlInjectionProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block common SQL injection
+      attacks.
+  CrossSiteScriptingProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block common XSS attacks.
+  ActivateHttpFloodProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block HTTP flood attacks.
+  ActivateScansProbesProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block scanners and
+      probes.
+  ActivateReputationListsProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: 'Choose yes to block requests from IP addresses on third-party reputation
+      lists (supported lists: spamhaus, torproject, and emergingthreats).'
+  ActivateBadBotProtectionParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Choose yes to enable the component designed to block bad bots and
+      content scrapers.
+  AccessLogBucket:
+    Type: String
+    Default: ''
+    AllowedPattern: (^$|^([a-z]|(\d(?!\d{0,2}\.\d{1,3}\.\d{1,3}\.\d{1,3})))([a-z\d]|(\.(?!(\.|-)))|(-(?!\.))){1,61}[a-z\d]$)
+    Description: "Enter a name for the Amazon S3 bucket where you want to store Amazon\
+      \ CloudFront access logs. This can be the name of either an existing S3 bucket,\
+      \ or a new bucket that the template will create during stack launch (if it does\
+      \ not find a matching bucket name). The solution will modify the bucket\xE2\u20AC\
+      \u2122s notification configuration to trigger the Log Parser AWS Lambda function\
+      \ whenever a new log file is saved in this bucket. More about bucket name restriction\
+      \ here: http://amzn.to/1p1YlU5"
+  SendAnonymousUsageData:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: Send anonymous data to AWS to help us understand solution usage across
+      our customer base as a whole. To opt out of this feature, select No.
+  RequestThreshold:
+    Type: Number
+    Default: '2000'
+    MinValue: '2000'
+    Description: If you chose yes for the Activate HTTP Flood Protection parameter,
+      enter the maximum acceptable requests per FIVE-minute period per IP address.
+      Minimum value of 2000. If you chose to deactivate this protection, ignore this
+      parameter.
+  ErrorThreshold:
+    Type: Number
+    Default: '50'
+    MinValue: '0'
+    Description: If you chose yes for the Activate Scanners & Probes Protection parameter,
+      enter the maximum acceptable bad requests per minute per IP. If you chose to
+      deactivate Scanners & Probes protection, ignore this parameter.
+  WAFBlockPeriod:
+    Type: Number
+    Default: '240'
+    MinValue: '0'
+    Description: If you chose yes for the Activate Scanners & Probes Protection parameters,
+      enter the period (in minutes) to block applicable IP addresses. If you chose
+      to deactivate this protection, ignore this parameter.
+Conditions:
+  SqlInjectionProtectionActivated: !Equals
+    - !Ref 'SqlInjectionProtectionParam'
+    - 'yes'
+  CrossSiteScriptingProtectionActivated: !Equals
+    - !Ref 'CrossSiteScriptingProtectionParam'
+    - 'yes'
+  HttpFloodProtectionActivated: !Equals
+    - !Ref 'ActivateHttpFloodProtectionParam'
+    - 'yes'
+  ScansProbesProtectionActivated: !Equals
+    - !Ref 'ActivateScansProbesProtectionParam'
+    - 'yes'
+  ReputationListsProtectionActivated: !Equals
+    - !Ref 'ActivateReputationListsProtectionParam'
+    - 'yes'
+  BadBotProtectionActivated: !Equals
+    - !Ref 'ActivateBadBotProtectionParam'
+    - 'yes'
+  LogParserActivated: !Equals
+    - !Ref 'ActivateScansProbesProtectionParam'
+    - 'yes'
+  CreateWebACL: !Or
+    - !Condition 'SqlInjectionProtectionActivated'
+    - !Condition 'CrossSiteScriptingProtectionActivated'
+    - !Condition 'HttpFloodProtectionActivated'
+    - !Condition 'ScansProbesProtectionActivated'
+    - !Condition 'ReputationListsProtectionActivated'
+    - !Condition 'BadBotProtectionActivated'
+Resources:
+  WAFWhitelistSet:
+    Type: AWS::WAF::IPSet
+    Condition: CreateWebACL
+    Properties:
+      Name: !Sub '${AWS::StackName} - Whitelist Set'
+  WAFBlacklistSet:
+    Type: AWS::WAF::IPSet
+    Condition: LogParserActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - Blacklist Set'
+  WAFScansProbesSet:
+    Type: AWS::WAF::IPSet
+    Condition: LogParserActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - Scans Probes Set'
+  WAFReputationListsSet1:
+    Type: AWS::WAF::IPSet
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Reputation Lists Set #1'
+  WAFReputationListsSet2:
+    Type: AWS::WAF::IPSet
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Reputation Lists Set #2'
+  WAFBadBotSet:
+    Type: AWS::WAF::IPSet
+    Condition: BadBotProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - IP Bad Bot Set'
+  WAFSqlInjectionDetection:
+    Type: AWS::WAF::SqlInjectionMatchSet
+    Condition: SqlInjectionProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - SQL injection Detection'
+      SqlInjectionMatchTuples:
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Authorization
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Authorization
+          TextTransformation: HTML_ENTITY_DECODE
+  WAFXssDetection:
+    Type: AWS::WAF::XssMatchSet
+    Condition: CrossSiteScriptingProtectionActivated
+    Properties:
+      Name: !Sub '${AWS::StackName} - XSS Detection Detection'
+      XssMatchTuples:
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: HTML_ENTITY_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: URL_DECODE
+        - FieldToMatch:
+            Type: HEADER
+            Data: Cookie
+          TextTransformation: HTML_ENTITY_DECODE
+  WAFWhitelistRule:
+    Type: AWS::WAF::Rule
+    Condition: CreateWebACL
+    DependsOn: WAFWhitelistSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Whitelist Rule'
+      MetricName: SecurityAutomationsWhitelistRule
+      Predicates:
+        - DataId: !Ref 'WAFWhitelistSet'
+          Negated: false
+          Type: IPMatch
+  WAFBlacklistRule:
+    Type: AWS::WAF::Rule
+    Condition: LogParserActivated
+    DependsOn: WAFBlacklistSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Blacklist Rule'
+      MetricName: SecurityAutomationsBlacklistRule
+      Predicates:
+        - DataId: !Ref 'WAFBlacklistSet'
+          Negated: false
+          Type: IPMatch
+  WAFScansProbesRule:
+    Type: AWS::WAF::Rule
+    Condition: LogParserActivated
+    DependsOn: WAFScansProbesSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Scans Probes Rule'
+      MetricName: SecurityAutomationsScansProbesRule
+      Predicates:
+        - DataId: !Ref 'WAFScansProbesSet'
+          Negated: false
+          Type: IPMatch
+  WAFIPReputationListsRule1:
+    Type: AWS::WAF::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn: WAFReputationListsSet1
+    Properties:
+      Name: !Sub '${AWS::StackName} - WAF IP Reputation Lists Rule #1'
+      MetricName: SecurityAutomationsIPReputationListsRule1
+      Predicates:
+        - DataId: !Ref 'WAFReputationListsSet1'
+          Type: IPMatch
+          Negated: 'false'
+  WAFIPReputationListsRule2:
+    Type: AWS::WAF::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn: WAFReputationListsSet2
+    Properties:
+      Name: !Sub '${AWS::StackName} - WAF IP Reputation Lists Rule #2'
+      MetricName: SecurityAutomationsIPReputationListsRule2
+      Predicates:
+        - DataId: !Ref 'WAFReputationListsSet2'
+          Type: IPMatch
+          Negated: 'false'
+  WAFBadBotRule:
+    Type: AWS::WAF::Rule
+    Condition: BadBotProtectionActivated
+    DependsOn: WAFBadBotSet
+    Properties:
+      Name: !Sub '${AWS::StackName} - Bad Bot Rule'
+      MetricName: SecurityAutomationsBadBotRule
+      Predicates:
+        - DataId: !Ref 'WAFBadBotSet'
+          Type: IPMatch
+          Negated: 'false'
+  WAFSqlInjectionRule:
+    Type: AWS::WAF::Rule
+    Condition: SqlInjectionProtectionActivated
+    DependsOn: WAFSqlInjectionDetection
+    Properties:
+      Name: !Sub '${AWS::StackName} - SQL Injection Rule'
+      MetricName: SecurityAutomationsSqlInjectionRule
+      Predicates:
+        - DataId: !Ref 'WAFSqlInjectionDetection'
+          Negated: false
+          Type: SqlInjectionMatch
+  WAFXssRule:
+    Type: AWS::WAF::Rule
+    Condition: CrossSiteScriptingProtectionActivated
+    DependsOn: WAFXssDetection
+    Properties:
+      Name: !Sub '${AWS::StackName} - XSS Rule'
+      MetricName: SecurityAutomationsXssRule
+      Predicates:
+        - DataId: !Ref 'WAFXssDetection'
+          Negated: false
+          Type: XssMatch
+  WAFWebACL:
+    Type: AWS::WAF::WebACL
+    Condition: CreateWebACL
+    DependsOn:
+      - WAFWhitelistRule
+    Properties:
+      Name: !Ref 'AWS::StackName'
+      DefaultAction:
+        Type: ALLOW
+      MetricName: SecurityAutomationsMaliciousRequesters
+      Rules:
+        - Action:
+            Type: ALLOW
+          Priority: 10
+          RuleId: !Ref 'WAFWhitelistRule'
+  LambdaRoleLogParser:
+    Type: AWS::IAM::Role
+    Condition: LogParserActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}/*'
+        - PolicyName: S3AccessPut
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}/aws-waf-security-automations-current-blocked-ips.json'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetIPSet
+                  - waf:UpdateIPSet
+                Resource:
+                  - !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/${WAFBlacklistSet}'
+                  - !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/${WAFScansProbesSet}'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFLogParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: LogParserActivated
+    DependsOn:
+      - LambdaRoleLogParser
+      - WAFBlacklistSet
+      - WAFScansProbesSet
+    Properties:
+      Description: !Sub 'This function parses CloudFront access logs to identify suspicious
+        behavior, such as an abnormal amount of errors. It then blocks those IP addresses
+        for a customer-defined period of time. Parameters: ${ErrorThreshold},${WAFBlockPeriod}.'
+      Handler: log-parser.lambda_handler
+      Role: !GetAtt 'LambdaRoleLogParser.Arn'
+      Code:
+        S3Bucket: !Sub '%%BUCKET_NAME%%-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v2/log-parser.zip
+      Environment:
+        Variables:
+          OUTPUT_BUCKET: !Ref 'AccessLogBucket'
+          IP_SET_ID_BLACKLIST: !Ref 'WAFBlacklistSet'
+          IP_SET_ID_AUTO_BLOCK: !Ref 'WAFScansProbesSet'
+          BLACKLIST_BLOCK_PERIOD: !Ref 'WAFBlockPeriod'
+          ERROR_PER_MINUTE_LIMIT: !Ref 'ErrorThreshold'
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+          LIMIT_IP_ADDRESS_RANGES_PER_IP_MATCH_CONDITION: '10000'
+          MAX_AGE_TO_UPDATE: '30'
+          REGION: !Ref 'AWS::Region'
+          LOG_TYPE: cloudfront
+      Runtime: python2.7
+      MemorySize: '512'
+      Timeout: '300'
+  LambdaInvokePermissionLogParser:
+    Type: AWS::Lambda::Permission
+    Condition: LogParserActivated
+    DependsOn: LambdaWAFLogParserFunction
+    Properties:
+      FunctionName: !GetAtt 'LambdaWAFLogParserFunction.Arn'
+      Action: lambda:*
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref 'AWS::AccountId'
+  LambdaRoleReputationListsParser:
+    Type: AWS::IAM::Role
+    Condition: ReputationListsProtectionActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetIPSet
+                  - waf:UpdateIPSet
+                Resource:
+                  - !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/${WAFReputationListsSet1}'
+                  - !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/${WAFReputationListsSet2}'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFReputationListsParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: ReputationListsProtectionActivated
+    DependsOn: LambdaRoleReputationListsParser
+    Properties:
+      Description: This lambda function checks third-party IP reputation lists hourly
+        for new IP ranges to block. These lists include the Spamhaus Dont Route Or
+        Peer (DROP) and Extended Drop (EDROP) lists, the Proofpoint Emerging Threats
+        IP list, and the Tor exit node list.
+      Handler: reputation-lists-parser.handler
+      Role: !GetAtt 'LambdaRoleReputationListsParser.Arn'
+      Code:
+        S3Bucket: !Sub '%%BUCKET_NAME%%-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v3/reputation-lists-parser.zip
+      Runtime: nodejs6.10
+      MemorySize: '128'
+      Timeout: '300'
+      Environment:
+        Variables:
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+  LambdaWAFReputationListsParserEventsRule:
+    Type: AWS::Events::Rule
+    Condition: ReputationListsProtectionActivated
+    DependsOn:
+      - LambdaWAFReputationListsParserFunction
+      - WAFReputationListsSet1
+      - WAFReputationListsSet2
+    Properties:
+      Description: Security Automations - WAF Reputation Lists
+      ScheduleExpression: rate(1 hour)
+      Targets:
+        - Arn: !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+          Id: LambdaWAFReputationListsParserFunction
+          Input: !Sub '{"lists":[{"url":"https://www.spamhaus.org/drop/drop.txt"},{"url":"https://check.torproject.org/exit-addresses","prefix":"ExitAddress
+            "},{"url":"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt"}],"logType":"cloudfront","region":"${AWS::Region}","ipSetIds":
+            ["${WAFReputationListsSet1}","${WAFReputationListsSet2}"]}'
+  LambdaInvokePermissionReputationListsParser:
+    Type: AWS::Lambda::Permission
+    Condition: ReputationListsProtectionActivated
+    DependsOn:
+      - LambdaWAFReputationListsParserFunction
+      - LambdaWAFReputationListsParserEventsRule
+    Properties:
+      FunctionName: !Ref 'LambdaWAFReputationListsParserFunction'
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt 'LambdaWAFReputationListsParserEventsRule.Arn'
+  LambdaRoleBadBot:
+    Type: AWS::IAM::Role
+    Condition: BadBotProtectionActivated
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf:GetChangeToken
+                Resource: '*'
+        - PolicyName: WAFGetAndUpdateIPSet
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetIPSet
+                  - waf:UpdateIPSet
+                Resource: !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/${WAFBadBotSet}'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: CloudWatchAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudwatch:GetMetricStatistics
+                Resource: '*'
+  LambdaWAFBadBotParserFunction:
+    Type: AWS::Lambda::Function
+    Condition: BadBotProtectionActivated
+    DependsOn: LambdaRoleBadBot
+    Properties:
+      Description: This lambda function will intercepts and inspects trap endpoint
+        requests to extract its IP address, and then add it to an AWS WAF block list.
+      Handler: access-handler.lambda_handler
+      Role: !GetAtt 'LambdaRoleBadBot.Arn'
+      Code:
+        S3Bucket: !Sub '%%BUCKET_NAME%%-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v2/access-handler.zip
+      Environment:
+        Variables:
+          IP_SET_ID_BAD_BOT: !Ref 'WAFBadBotSet'
+          SEND_ANONYMOUS_USAGE_DATA: !Ref 'SendAnonymousUsageData'
+          UUID: !GetAtt 'CreateUniqueID.UUID'
+          REGION: !Ref 'AWS::Region'
+          LOG_TYPE: cloudfront
+      Runtime: python2.7
+      MemorySize: '128'
+      Timeout: '300'
+  LambdaInvokePermissionBadBot:
+    Type: AWS::Lambda::Permission
+    Condition: BadBotProtectionActivated
+    DependsOn: LambdaWAFBadBotParserFunction
+    Properties:
+      FunctionName: !GetAtt 'LambdaWAFBadBotParserFunction.Arn'
+      Action: lambda:*
+      Principal: apigateway.amazonaws.com
+  ApiGatewayBadBot:
+    Type: AWS::ApiGateway::RestApi
+    Condition: BadBotProtectionActivated
+    Properties:
+      Name: Security Automations - WAF Bad Bot API
+      Description: API created by AWS WAF Security Automations CloudFormation template.
+        This endpoint will be used to capture bad bots.
+  ApiGatewayBadBotResource:
+    Type: AWS::ApiGateway::Resource
+    Condition: BadBotProtectionActivated
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ParentId: !GetAtt 'ApiGatewayBadBot.RootResourceId'
+      PathPart: '{proxy+}'
+  ApiGatewayBadBotMethodRoot:
+    Type: AWS::ApiGateway::Method
+    Condition: BadBotProtectionActivated
+    DependsOn:
+      - LambdaWAFBadBotParserFunction
+      - LambdaInvokePermissionBadBot
+      - ApiGatewayBadBot
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ResourceId: !GetAtt 'ApiGatewayBadBot.RootResourceId'
+      HttpMethod: ANY
+      AuthorizationType: NONE
+      RequestParameters:
+        method.request.header.X-Forwarded-For: false
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations'
+  ApiGatewayBadBotMethod:
+    Type: AWS::ApiGateway::Method
+    Condition: BadBotProtectionActivated
+    DependsOn:
+      - LambdaWAFBadBotParserFunction
+      - LambdaInvokePermissionBadBot
+      - ApiGatewayBadBot
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      ResourceId: !Ref 'ApiGatewayBadBotResource'
+      HttpMethod: ANY
+      AuthorizationType: NONE
+      RequestParameters:
+        method.request.header.X-Forwarded-For: false
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaWAFBadBotParserFunction.Arn}/invocations'
+  ApiGatewayBadBotDeployment:
+    Type: AWS::ApiGateway::Deployment
+    Condition: BadBotProtectionActivated
+    DependsOn: ApiGatewayBadBotMethod
+    Properties:
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      Description: CloudFormation Deployment Stage
+      StageName: CFDeploymentStage
+  ApiGatewayBadBotStage:
+    Type: AWS::ApiGateway::Stage
+    Condition: BadBotProtectionActivated
+    DependsOn: ApiGatewayBadBotDeployment
+    Properties:
+      DeploymentId: !Ref 'ApiGatewayBadBotDeployment'
+      Description: Production Stage
+      RestApiId: !Ref 'ApiGatewayBadBot'
+      StageName: ProdStage
+  LambdaRoleCustomResource:
+    Type: AWS::IAM::Role
+    Condition: CreateWebACL
+    DependsOn: WAFWebACL
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: S3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                  - s3:GetBucketLocation
+                  - s3:GetBucketNotification
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:PutBucketNotification
+                Resource: !Sub 'arn:aws:s3:::${AccessLogBucket}'
+        - !If
+          - ReputationListsProtectionActivated
+          - PolicyName: LambdaAccess
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action: lambda:InvokeFunction
+                  Resource: !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+          - !Ref 'AWS::NoValue'
+        - PolicyName: WAFAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetWebACL
+                  - waf:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf::${AWS::AccountId}:webacl/${WAFWebACL}'
+        - PolicyName: WAFRuleAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetRule
+                  - waf:GetIPSet
+                  - waf:UpdateIPSet
+                  - waf:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf::${AWS::AccountId}:rule/*'
+        - PolicyName: WAFIPSetAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetIPSet
+                  - waf:UpdateIPSet
+                Resource: !Sub 'arn:aws:waf::${AWS::AccountId}:ipset/*'
+        - PolicyName: WAFRateBasedRuleAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - waf:GetRateBasedRule
+                  - waf:CreateRateBasedRule
+                  - waf:DeleteRateBasedRule
+                  - waf:ListRateBasedRules
+                  - waf:UpdateWebACL
+                Resource: !Sub 'arn:aws:waf::${AWS::AccountId}:ratebasedrule/*'
+        - PolicyName: CloudFormationAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: cloudformation:DescribeStacks
+                Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*'
+        - PolicyName: WAFGetChangeToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: waf:GetChangeToken
+                Resource: '*'
+        - PolicyName: LogsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+  LambdaWAFCustomResourceFunction:
+    Type: AWS::Lambda::Function
+    Condition: CreateWebACL
+    DependsOn: LambdaRoleCustomResource
+    Properties:
+      Description: This lambda function configures the Web ACL rules based on the
+        features enabled in the CloudFormation template.
+      Handler: custom-resource.lambda_handler
+      Role: !GetAtt 'LambdaRoleCustomResource.Arn'
+      Code:
+        S3Bucket: !Sub '%%BUCKET_NAME%%-${AWS::Region}'
+        S3Key: aws-waf-security-automations/v4/custom-resource.zip
+      Runtime: python2.7
+      MemorySize: '128'
+      Timeout: '300'
+  WafWebAclRuleControler:
+    Type: Custom::WafWebAclRuleControler
+    Condition: CreateWebACL
+    DependsOn:
+      - LambdaWAFCustomResourceFunction
+      - WAFWebACL
+    Properties:
+      ServiceToken: !GetAtt 'LambdaWAFCustomResourceFunction.Arn'
+      StackName: !Ref 'AWS::StackName'
+      WAFWebACL: !Ref 'WAFWebACL'
+      Region: !Ref 'AWS::Region'
+      LambdaWAFReputationListsParserFunction: !If
+        - ReputationListsProtectionActivated
+        - !GetAtt 'LambdaWAFReputationListsParserFunction.Arn'
+        - !Ref 'AWS::NoValue'
+      WAFWhitelistSet: !Ref 'WAFWhitelistSet'
+      WAFBlacklistSet: !If
+        - LogParserActivated
+        - !Ref 'WAFBlacklistSet'
+        - !Ref 'AWS::NoValue'
+      WAFScansProbesSet: !If
+        - ScansProbesProtectionActivated
+        - !Ref 'WAFScansProbesSet'
+        - !Ref 'AWS::NoValue'
+      WAFReputationListsSet1: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFReputationListsSet1'
+        - !Ref 'AWS::NoValue'
+      WAFReputationListsSet2: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFReputationListsSet2'
+        - !Ref 'AWS::NoValue'
+      WAFBadBotSet: !If
+        - BadBotProtectionActivated
+        - !Ref 'WAFBadBotSet'
+        - !Ref 'AWS::NoValue'
+      AccessLogBucket: !If
+        - LogParserActivated
+        - !Ref 'AccessLogBucket'
+        - !Ref 'AWS::NoValue'
+      LambdaWAFLogParserFunction: !If
+        - LogParserActivated
+        - !GetAtt 'LambdaWAFLogParserFunction.Arn'
+        - !Ref 'AWS::NoValue'
+      WAFWhitelistRule: !If
+        - CreateWebACL
+        - !Ref 'WAFWhitelistRule'
+        - !Ref 'AWS::NoValue'
+      WAFBlacklistRule: !If
+        - LogParserActivated
+        - !Ref 'WAFBlacklistRule'
+        - !Ref 'AWS::NoValue'
+      WAFScansProbesRule: !If
+        - LogParserActivated
+        - !Ref 'WAFScansProbesRule'
+        - !Ref 'AWS::NoValue'
+      WAFIPReputationListsRule1: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFIPReputationListsRule1'
+        - !Ref 'AWS::NoValue'
+      WAFIPReputationListsRule2: !If
+        - ReputationListsProtectionActivated
+        - !Ref 'WAFIPReputationListsRule2'
+        - !Ref 'AWS::NoValue'
+      WAFBadBotRule: !If
+        - BadBotProtectionActivated
+        - !Ref 'WAFBadBotRule'
+        - !Ref 'AWS::NoValue'
+      WAFSqlInjectionRule: !If
+        - SqlInjectionProtectionActivated
+        - !Ref 'WAFSqlInjectionRule'
+        - !Ref 'AWS::NoValue'
+      WAFXssRule: !If
+        - CrossSiteScriptingProtectionActivated
+        - !Ref 'WAFXssRule'
+        - !Ref 'AWS::NoValue'
+      SqlInjectionProtection: !Ref 'SqlInjectionProtectionParam'
+      CrossSiteScriptingProtection: !Ref 'CrossSiteScriptingProtectionParam'
+      ActivateHttpFloodProtection: !Ref 'ActivateHttpFloodProtectionParam'
+      ActivateScansProbesProtection: !Ref 'ActivateScansProbesProtectionParam'
+      ActivateReputationListsProtection: !Ref 'ActivateReputationListsProtectionParam'
+      ActivateBadBotProtection: !Ref 'ActivateBadBotProtectionParam'
+      RequestThreshold: !Ref 'RequestThreshold'
+      ErrorThreshold: !Ref 'ErrorThreshold'
+      WAFBlockPeriod: !Ref 'WAFBlockPeriod'
+      SendAnonymousUsageData: !Ref 'SendAnonymousUsageData'
+      UUID: !GetAtt 'CreateUniqueID.UUID'
+      LOG_TYPE: cloudfront
+  SolutionHelperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: Solution_Helper_Permissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*'
+  SolutionHelper:
+    Type: AWS::Lambda::Function
+    DependsOn: SolutionHelperRole
+    Properties:
+      Handler: solution-helper.lambda_handler
+      Role: !GetAtt 'SolutionHelperRole.Arn'
+      Description: This lambda function executes generic common tasks to support this
+        solution.
+      Code:
+        S3Bucket: !Sub 'solutions-${AWS::Region}'
+        S3Key: library/solution-helper/v1/solution-helper.zip
+      Runtime: python2.7
+      Timeout: '300'
+  CreateUniqueID:
+    Type: Custom::CreateUUID
+    DependsOn: SolutionHelper
+    Properties:
+      ServiceToken: !GetAtt 'SolutionHelper.Arn'
+      Region: !Ref 'AWS::Region'
+      CreateUniqueID: 'true'
+Outputs:
+  BadBotHoneypotEndpoint:
+    Description: Bad Bot Honeypot Endpoint
+    Value: !Sub 'https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}'
+    Condition: BadBotProtectionActivated
+  WAFWebACL:
+    Description: AWS WAF WebACL ID
+    Value: !Ref 'WAFWebACL'
+    Condition: CreateWebACL

--- a/source/custom-resource/custom-resource.py
+++ b/source/custom-resource/custom-resource.py
@@ -43,7 +43,7 @@ def update_web_acl(web_acl_id, updates):
                     Updates=updates,
                     DefaultAction={'Type': 'ALLOW'}
                 )
-            except Exception, e:
+            except Exception as e:
                 print(e)
                 delay = math.pow(2, attempt)
                 print("[update_web_acl] Retrying in %d seconds..." % (delay))
@@ -153,7 +153,7 @@ def remove_s3_bucket_lambda_event(bucket_name, lambda_function_arn):
 
         response = s3_client.put_bucket_notification_configuration(Bucket=bucket_name, NotificationConfiguration=new_conf)
 
-    except Exception, e:
+    except Exception as e:
         print(e)
         print("[ERROR] Error to remove S3 Bucket lambda event")
 
@@ -179,7 +179,7 @@ def get_or_create_rate_based_rule(stack_name, resource_properties):
                     response = waf.list_rate_based_rules(NextMarker=response['NextMarker'], Limit=LIST_LIMIT)
                     keep_looking = (len(response['Rules']) > 0)
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[get_or_create_rate_based_rule] Retrying in %d seconds..." % (delay))
@@ -205,7 +205,7 @@ def get_or_create_rate_based_rule(stack_name, resource_properties):
 
                 rule_id = response['Rule']['RuleId'].encode('utf8').strip()
 
-            except Exception, e:
+            except Exception as e:
                 print(e)
                 delay = math.pow(2, attempt)
                 print("[get_or_create_rate_based_rule] Retrying in %d seconds..." % (delay))
@@ -241,7 +241,7 @@ def delete_rate_based_rules(stack_name):
                     response = waf.list_rate_based_rules(NextMarker=response['NextMarker'], Limit=LIST_LIMIT)
                     keep_looking = (len(response['Rules']) > 0)
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[delete_rate_based_rules] Retrying in %d seconds..." % (delay))
@@ -272,7 +272,7 @@ def clean_ip_set(ip_set_id):
                     if counter >= BATCH_DELETE_LIMIT:
                         break
 
-                print "[clean_ip_set] Deleting %d IPs..."%len(updates)
+                print ("[clean_ip_set] Deleting %d IPs..."%len(updates))
                 waf.update_ip_set(
                     IPSetId=ip_set_id,
                     ChangeToken=waf.get_change_token()['ChangeToken'],
@@ -280,7 +280,7 @@ def clean_ip_set(ip_set_id):
                 )
                 response = waf.get_ip_set(IPSetId=ip_set_id)
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[clean_ip_set] Error to clean IP Set %s. Retrying in %d seconds..."%ip_set_id, delay)
@@ -310,7 +310,7 @@ def create_stack(stack_name, resource_properties):
             response = waf.get_web_acl(WebACLId=resource_properties['WAFWebACL'])
             current_rules = [r['RuleId'].encode('utf8') for r in response['WebACL']['Rules']]
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[create_stack] Retrying in %d seconds..." % (delay))
@@ -459,7 +459,7 @@ def create_stack(stack_name, resource_properties):
                       ]
                     }"""%(resource_properties['LOG_TYPE'], resource_properties['Region'], resource_properties['WAFReputationListsSet1'], resource_properties['WAFReputationListsSet2'])
             )
-        except Exception, e:
+        except Exception as e:
             print(e)
             print("[ERROR] Failed to call IP Reputation List function")
 
@@ -510,7 +510,7 @@ def delete_stack(stack_name, resource_properties, force_delete):
                     for ip_set_id in ipsets_to_clean:
                         clean_ip_set(ip_set_id)
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[delete_stack] Retrying in %d seconds..." % (delay))
@@ -557,7 +557,7 @@ def can_delete_rule(stack_name, resource_properties, rule_id, rule_type, force_d
                     if p['Type'] == 'IPMatch':
                         ipsets_to_clean.append(p['DataId'].encode('utf8'))
 
-        except Exception, e:
+        except Exception as e:
             print(e)
             delay = math.pow(2, attempt)
             print("[can_delete_rule] Retrying in %d seconds..." % (delay))
@@ -639,7 +639,7 @@ def send_anonymous_usage_data(action_type, resource_properties):
         print('[send_anonymous_usage_data] Response Content: {}'.format(content))
 
         print("[send_anonymous_usage_data] End")
-    except Exception, e:
+    except Exception as e:
         print(e)
         print("[send_anonymous_usage_data] Failed to Send Data")
 


### PR DESCRIPTION
- Added YAML versions of the cloud formation templates
 - Formatted the cloud formation templates using the 'clean' ability of the cfn-flip command
 - Fixed a number of python linting issues
 - Added the ability to specify a rule action rather than just BLOCK. This allows the rule action to be specified as COUNT for testing purposes and to ensure the rules are appropriate

