### PR TITLE
add EDROP list

### DIFF
--- a/deployment/aws-waf-security-automations-alb.template
+++ b/deployment/aws-waf-security-automations-alb.template
@@ -927,7 +927,7 @@
             "Fn::Join": [
               "", [
                 "{\"lists\":",
-                "[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}]",
+                "[{\"url\":\"https://www.spamhaus.org/drop/drop.txt\"},{\"url\":\"https://www.spamhaus.org/drop/edrop.txt\"},{\"url\":\"https://check.torproject.org/exit-addresses\",\"prefix\":\"ExitAddress \"},{\"url\":\"https://rules.emergingthreats.net/fwrules/emerging-Block-IPs.txt\"}]",
                 ",\"logType\":\"alb\"",
                 ",\"region\":\"", {
                   "Ref": "AWS::Region"


### PR DESCRIPTION
Hi, I noticed that the reputation list parser Lambda description says it uses the Spamhaus EDROP list, but only the DROP list is included in the triggering event.