### PR TITLE
Fixed BadBotParser DoS. Updated Source IP extraction logic from event

### DIFF
--- a/source/access-handler/access-handler.py
+++ b/source/access-handler/access-handler.py
@@ -218,7 +218,7 @@ def lambda_handler(event, context):
         # Read inputs parameters
         #----------------------------------------------------------
         logging.getLogger().info(event)
-        source_ip = event['headers']['X-Forwarded-For'].split(',')[0].strip()
+        source_ip = event['requestContext']['identity']['sourceIp']
 
         waf_update_ip_set(environ['IP_SET_ID_BAD_BOT'], source_ip)
 


### PR DESCRIPTION
*Issue #, if available:* -

### Description of changes:
File "aws-waf-security-automations/source/access-handler/access-handler.py" is responsible for processing requests hitting the BadBotHoneypotEndpoint. Following line in the code is responsible for extracting IP address from the event object:
```
221         source_ip = event['headers']['X-Forwarded-For'].split(',')[0].strip()
```
If a malicious user crafts a request to this endpoint by passing an X-Forwarded-For header set to a random IP address, this handler blacklists the user supplied IP address instead of blacklisting the actual source IP address. When I checked CloudWatch logs for the requests sent with an 'X-Forwarded-For' header, I saw that the headers were set to 'X-Forwarded-For': [‘2.3.4.5, X.X.X.X, 130.176.20.90’], where X.X.X.X was my actual IP address and 2.3.4.5 was the user-supplied IP address. The Lambda code will split the string by commas into an array and picked the [0] element for blacklisting. Hence, it will pick the user-supplied IP address from the HTTP header and send it for blacklisting.

### The Fix:
To fix this vulnerability, I have updated the code to extract the source IP address as follows:
```
221         source_ip = event['requestContext']['identity']['sourceIp']
```
This is a much reliable source for identifying the correct IP address for the bad bot and is not vulnerable to spoofing through XFF header.

I notified aws-security@amazon.com regarding this issue. They have acknowledged it and  requested me to open a PR here for quick closure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
