### PR TITLE
Ensure pip3 is used

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -1,53 +1,53 @@
 #!/bin/bash
-# This assumes all of the OS-level configuration has been completed and git repo has already been cloned 
-# 
-# This script should be run from the repo's deployment directory 
-# cd deployment 
-# ./build-s3-dist.sh source-bucket-base-name trademarked-solution-name version-code 
-# 
-# Paramenters: 
+# This assumes all of the OS-level configuration has been completed and git repo has already been cloned
+#
+# This script should be run from the repo's deployment directory
+# cd deployment
+# ./build-s3-dist.sh source-bucket-base-name trademarked-solution-name version-code
+#
+# Paramenters:
 #  - template-bucket: Name for the S3 bucket location where the templates are found
-#  - source-bucket-base-name: Name for the S3 bucket location where the Lambda source 
+#  - source-bucket-base-name: Name for the S3 bucket location where the Lambda source
 #    code is deployed. The template will append '-[region_name]' to this bucket name.
-#  - trademarked-solution-name: name of the solution for consistency 
-#  - version-code: version of the package 
+#  - trademarked-solution-name: name of the solution for consistency
+#  - version-code: version of the package
 #
 #    For example: ./build-s3-dist.sh template-bucket source-bucket-base-name my-solution v3.0
-#    The template will then expect the source code to be located in the solutions-[region_name] bucket 
-# 
-# Check to see if input has been provided: 
-if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then 
-    echo "Please provide the base template-bucket, source-bucket-base-name, trademark-approved-solution-name and version" 
-    echo "For example: ./build-s3-dist.sh solutions solutions-code trademarked-solution-name v3.0" 
-    exit 1 
-fi 
+#    The template will then expect the source code to be located in the solutions-[region_name] bucket
+#
+# Check to see if input has been provided:
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
+    echo "Please provide the base template-bucket, source-bucket-base-name, trademark-approved-solution-name and version"
+    echo "For example: ./build-s3-dist.sh solutions solutions-code trademarked-solution-name v3.0"
+    exit 1
+fi
 
 echo "template bucket = $1"
 echo "source bucket = $2"
 echo "solution = $3"
 echo "version = $4"
 
-# Get reference for all important folders 
-template_dir="$PWD" 
-source_dir="$template_dir/../source" 
+# Get reference for all important folders
+template_dir="$PWD"
+source_dir="$template_dir/../source"
 
 # There are now TWO dist directories
-template_dist_dir="$template_dir/global-s3-assets" 
-build_dist_dir="$template_dir/regional-s3-assets" 
+template_dist_dir="$template_dir/global-s3-assets"
+build_dist_dir="$template_dir/regional-s3-assets"
 
 echo "------------------------------------------------------------------------------"
 echo "[Init] Clean old dist folders"
 echo "------------------------------------------------------------------------------"
 
-echo "rm -rf $template_dist_dir" 
-rm -rf $template_dist_dir 
-echo "mkdir -p $template_dist_dir" 
-mkdir -p $template_dist_dir 
+echo "rm -rf $template_dist_dir"
+rm -rf $template_dist_dir
+echo "mkdir -p $template_dist_dir"
+mkdir -p $template_dist_dir
 
-echo "rm -rf $build_dist_dir" 
-rm -rf $build_dist_dir 
-echo "mkdir -p $build_dist_dir" 
-mkdir -p $build_dist_dir 
+echo "rm -rf $build_dist_dir"
+rm -rf $build_dist_dir
+echo "mkdir -p $build_dist_dir"
+mkdir -p $build_dist_dir
 
 echo "find $source_dir -iname \"dist\" -type d -exec rm -r \"{}\" \; 2> /dev/null"
 find "$source_dir" -iname "dist" -type d -exec rm -r "{}" \; 2> /dev/null
@@ -79,7 +79,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] Log Parser"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/log_parser || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/log_parser/package || exit 1
 zip -q -r9 "$build_dist_dir"/log_parser.zip .
 cd "$source_dir"/log_parser || exit 1
@@ -91,7 +91,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] Access Handler"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/access_handler || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/access_handler/package || exit 1
 zip -q -r9 "$build_dist_dir"/access_handler.zip .
 cd "$source_dir"/access_handler || exit 1
@@ -103,7 +103,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] IP Lists Parser"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/reputation_lists_parser || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/reputation_lists_parser/package || exit 1
 zip -q -r9 "$build_dist_dir"/reputation_lists_parser.zip .
 cd "$source_dir"/reputation_lists_parser || exit 1
@@ -115,7 +115,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] Custom Resource"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/custom_resource || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/custom_resource/package || exit 1
 zip -q -r9 "$build_dist_dir"/custom_resource.zip .
 cd "$source_dir"/custom_resource || exit 1
@@ -127,7 +127,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] Helper"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/helper || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/helper/package || exit 1
 zip -q -r9 "$build_dist_dir"/helper.zip ./*
 cd "$source_dir"/helper || exit 1
@@ -139,7 +139,7 @@ echo "--------------------------------------------------------------------------
 echo "[Packing] Timer"
 echo "------------------------------------------------------------------------------"
 cd "$source_dir"/timer || exit 1
-pip install -r requirements.txt --target ./package
+python3 -m pip install -r requirements.txt --target ./package
 cd "$source_dir"/timer/package || exit 1
 zip -q -r9 "$build_dist_dir"/timer.zip ./*
 cd "$source_dir"/timer || exit 1


### PR DESCRIPTION
Easier than trying to figure out if `pip` is running Python 3 or Python2, I opted for `python3 -m pip`

Also: delete trailing whitespace throughout.

Fixes #153.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
