### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ chmod +x ./build-s3-dist.sh && ./build-s3-dist.sh $TEMPLATE_OUTPUT_BUCKET $DIST_
 ```
 #### 06. Upload deployment assets to your Amazon S3 buckets:
 ```
-aws s3 cp ./deployment/global-s3-assets s3://$TEMPLATE_OUTPUT_BUCKET/aws-waf-security-automations/$VERSION --recursive --acl bucket-owner-full-control
-aws s3 cp ./deployment/regional-s3-assets s3://$DIST_OUTPUT_BUCKET-$AWS_REGION/aws-waf-security-automations/$VERSION --recursive --acl bucket-owner-full-control
+aws s3 cp ./deployment/global-s3-assets s3://$TEMPLATE_OUTPUT_BUCKET/$SOLUTION_NAME/$VERSION --recursive --acl bucket-owner-full-control
+aws s3 cp ./deployment/regional-s3-assets s3://$DIST_OUTPUT_BUCKET-$AWS_REGION/$SOLUTION_NAME/$VERSION --recursive --acl bucket-owner-full-control
 ```
 #### _Note:_ You must use proper acl and profile for the copy operation as applicable.
 


### PR DESCRIPTION
Update S3 bucket upload path with SOLUTION_NAME variable for situation where someone decides to use a different solution name. Adding SOLUTION_NAME in S3 bucket upload path will make sure that user will not face any issue while deploying CloudFormation template, as template uses SOLUTION_NAME as KeyPrefix in the mapping.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
