### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ aws s3 cp ./deployment/regional-s3-assets s3://$DIST_OUTPUT_BUCKET-$AWS_REGION/$
 ## Deploy
 
 * From your designated Amazon S3 bucket where you uploaded the deployment assets, copy the link location for the aws-waf-security-automations.template.
-* Using AWS CloudFormation, launch the AWS WAF Security Automations solution stack using the copied Amazon S3 link for the aws-waf-security-automations.template.
+* Using AWS CloudFormation, launch the AWS WAF Security Automations solution stack using the copied Amazon S3 link for the aws-waf-security-automations.template.  
+
+When deploying the template for CloufFront, you can launch it only from `us-east-1`.
 
 <a name="file-structure"></a>
 # File structure


### PR DESCRIPTION
*Description of changes:*
Adding default nature of CloudFormation which can create WAF Rules for CloudFront only from us-east-1. 
This was a commonly repeated mistake of Stack Deploy failure when launching from other regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
