### PR TITLE
Release v4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.0.4] - 2024-09-23
+
+### Fixed
+- Patched dependency version of `requests` to `2.32.3` to mitigate [CVE-2024-3651](https://nvd.nist.gov/vuln/detail/CVE-2024-3651)
+- Pinned all dependencies to specific versions for reproducable builds and enable security scanning
+- Allow to install latest version of `urllib3` as transitive dependency
+
 ## [4.0.3] - 2023-10-25
 
 ### Fixed

--- a/source/access_handler/requirements.txt
+++ b/source/access_handler/requirements.txt
@@ -1,3 +1,2 @@
-requests~=2.31.0
-backoff~=2.2.1
-urllib3<2
+requests==2.32.3
+backoff==2.2.1

--- a/source/custom_resource/requirements.txt
+++ b/source/custom_resource/requirements.txt
@@ -1,3 +1,2 @@
-requests~=2.31.0
-backoff~=2.2.1
-urllib3<2
+requests==2.32.3
+backoff==2.2.1

--- a/source/helper/requirements.txt
+++ b/source/helper/requirements.txt
@@ -1,3 +1,2 @@
-backoff~=2.2.1
-requests~=2.31.0
-urllib3<2
+backoff==2.2.1
+requests==2.32.3

--- a/source/ip_retention_handler/requirements.txt
+++ b/source/ip_retention_handler/requirements.txt
@@ -1,3 +1,2 @@
-requests~=2.31.0
-backoff~=2.2.1
-urllib3<2
+requests==2.32.3
+backoff==2.2.1

--- a/source/log_parser/requirements.txt
+++ b/source/log_parser/requirements.txt
@@ -1,3 +1,2 @@
-backoff~=2.2.1
-requests~=2.31.0
-urllib3<2
+backoff==2.2.1
+requests==2.32.3

--- a/source/reputation_lists_parser/requirements.txt
+++ b/source/reputation_lists_parser/requirements.txt
@@ -1,3 +1,2 @@
-requests~=2.31.0
-backoff~=2.2.1
-urllib3<2
+requests==2.32.3
+backoff==2.2.1

--- a/source/timer/requirements.txt
+++ b/source/timer/requirements.txt
@@ -1,2 +1,1 @@
-requests~=2.31.0
-urllib3<2
+requests==2.32.3


### PR DESCRIPTION
### Fixed
- Patched dependency version of `requests` to `2.32.3` to mitigate [CVE-2024-3651](https://nvd.nist.gov/vuln/detail/CVE-2024-3651)
- Pinned all dependencies to specific versions for reproducable builds and enable security scanning
- Allow to install latest version of `urllib3` as transitive dependency
